### PR TITLE
feat: add huge pages support for pktbuf pool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,10 +67,10 @@ target_link_libraries(test_suite pthread)
 add_test(NAME UPE_Unit_Tests COMMAND test_suite)
 
 # -- Benchmarks --
-add_executable(benchmark_pktbuf tests/benchmark_pktbuf.c src/pktbuf.c src/benchmark_test.c)
+add_executable(benchmark_pktbuf tests/benchmark_pktbuf.c src/pktbuf.c src/benchmark_test.c src/log.c)
 target_include_directories(benchmark_pktbuf PRIVATE include)
 target_link_libraries(benchmark_pktbuf pthread m)
 
-add_executable(benchmark_throughput tests/benchmark_throughput.c src/pktbuf.c src/ring.c src/rule_table.c src/worker.c src/parser.c src/log.c src/arp_table.c src/ndp_table.c src/affinity.c src/benchmark_test.c)
+add_executable(benchmark_throughput tests/benchmark_throughput.c src/pktbuf.c src/ring.c src/rule_table.c src/worker.c src/parser.c src/log.c src/arp_table.c src/ndp_table.c src/affinity.c src/benchmark_test.c src/log.c)
 target_include_directories(benchmark_throughput PRIVATE include)
 target_link_libraries(benchmark_throughput pthread m)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -34,6 +34,12 @@ The global pool uses `atomic_compare_exchange_weak_explicit` instead of mutexes:
 *   On success, using `memory_order_acq_rel` we can make sure that the buffer pointers are visible to other threads.
 *   On failure, we use `memory_order_acquire` to get the latest state.
 
+### Huge Pages
+
+The buffer array is allocated using `mmap` with 2MB huge pages to reduce TLB usage from many 4KB entries to a few entries (2MB pages).
+
+It requires pre-allocated huge pages. If missing, then `mmap` with regular pages are used. If that's failing, then we're falling back to `calloc` (standard heap allocation).
+
 ### Key functions
 
 *   **`pktbuf_pool_init`**: Pre-allocates all buffers in a single contignous block. Initializes the free stack with pointers to all buffers.

--- a/include/pktbuf.h
+++ b/include/pktbuf.h
@@ -13,10 +13,12 @@ typedef struct pktbuf {
 } pktbuf_t;
 
 typedef struct {
-    pktbuf_t *buffers;     // Contiguous array of all buffers.
-    pktbuf_t **free_stack; // Stack of pointers to free buffers.
-    _Atomic size_t top;    // Stack top index, modified using atomic CAS.
-    size_t capacity;       // Total number of buffers in the pool.
+    pktbuf_t *buffers;       // Contiguous array of all buffers.
+    pktbuf_t **free_stack;   // Stack of pointers to free buffers.
+    _Atomic size_t top;      // Stack top index, modified using atomic CAS.
+    size_t capacity;         // Total number of buffers in the pool.
+    size_t buffers_mmap_len; // Size of mmap (rounded to 2MB). 0 if calloc was used.
+    bool use_hugepages;      // Whether to use hugepages (informational).
 } pktbuf_pool_t;
 
 int pktbuf_pool_init(pktbuf_pool_t *p, size_t capacity);

--- a/src/main.c
+++ b/src/main.c
@@ -258,6 +258,8 @@ int main(int argc, char **argv) {
         log_msg(LOG_ERROR, "pktbuf_pool_init failed");
         return 1;
     }
+    log_msg(LOG_INFO, "Packet pool uses %s",
+            pool.use_hugepages ? "2MB huge pages" : "standard pages");
 
     // II. Init rings; one per worker.
     spsc_ring_t *rings = calloc((size_t)WORKERS_NUM, sizeof(spsc_ring_t));


### PR DESCRIPTION
Add support for huge pages in the Packet Buffer pool.

This is to reduce TLB entries needed. CPU needs to track much less TLB entries with 2MB huge pages (~4 entries) than with 4KB pages (~2000 entries).