### PR TITLE
fix: add missing break when EOF received from pcap file

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -377,6 +377,7 @@ int main(int argc, char **argv) {
     rx_start(&rx);
 
     // IX. RX returned => stop workers and join
+    sleep(1);
     g_stop = 1;
 
     // Join stats thread

--- a/src/rx_pcap.c
+++ b/src/rx_pcap.c
@@ -151,6 +151,12 @@ int rx_start(rx_ctx_t *rx) {
         // It's guaranteed to run at least once every milisecond (1ms timeout coming from
         // pcap_open_live)
         flush_rx_buffers(rx);
+
+        // EOF on pcap file
+        if (rc == 0 && rx->pcap_file) {
+            log_msg(LOG_INFO, "Pcap file done");
+            break;
+        }
     }
 
     pcap_close(g_pcap);


### PR DESCRIPTION
The loop didn't break when EOF was received from the Pcap file. Break was only implemented for rc < 0. Loop was going forever.