### PR TITLE
feat: expire stale neighbour entries

### DIFF
--- a/include/arp_table.h
+++ b/include/arp_table.h
@@ -7,6 +7,9 @@
 #include <stdint.h>
 #include <time.h>
 
+/* Entries must be refreshed within this window or will be removed. */
+#define ARP_TIMEOUT_SEC 300
+
 typedef struct {
     uint32_t ip;
     uint8_t mac[6];
@@ -31,5 +34,12 @@ void arp_update(arp_table_t *t, uint32_t ip, const uint8_t *mac);
         Return true if found, false otherwise.
 */
 bool arp_get_mac(arp_table_t *t, uint32_t ip, uint8_t *out_mac);
+
+/*
+    Remove all entries that have update_at older than ARP_TIMEOUT_SEC seconds
+    relative to `now`.
+        Returns the number of entries that were evicted.
+*/
+size_t arp_expire(arp_table_t *t, time_t now);
 
 #endif

--- a/include/ndp_table.h
+++ b/include/ndp_table.h
@@ -7,6 +7,9 @@
 #include <stdint.h>
 #include <time.h>
 
+/* Entries must be refreshed within this window or will be removed. */
+#define NDP_TIMEOUT_SEC 300
+
 typedef struct {
     uint8_t ip[16];
     uint8_t mac[6];
@@ -31,5 +34,12 @@ void ndp_update(ndp_table_t *t, const uint8_t *ip, const uint8_t *mac);
         Return true if found, false otherwise.
 */
 bool ndp_get_mac(ndp_table_t *t, const uint8_t *ip, uint8_t *out_mac);
+
+/*
+    Remove all entries that have update_at older than NDP_TIMEOUT_SEC seconds
+    relative to `now`.
+        Returns the number of entries that were evicted.
+*/
+size_t ndp_expire(ndp_table_t *t, time_t now);
 
 #endif

--- a/src/arp_table.c
+++ b/src/arp_table.c
@@ -4,8 +4,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define ARP_TIMEOUT_SEC 300
-
 int arp_table_init(arp_table_t *t, size_t capacity) {
     if (!t || capacity == 0 || (capacity & (capacity - 1)) != 0) return -1;
 
@@ -79,4 +77,61 @@ bool arp_get_mac(arp_table_t *t, uint32_t ip, uint8_t *out_mac) {
     pthread_rwlock_unlock(&t->lock);
 
     return false;
+}
+
+size_t arp_expire(arp_table_t *t, time_t now) {
+    if (!t) return 0;
+
+    size_t evicted = 0;
+
+    pthread_rwlock_wrlock(&t->lock);
+
+    for (size_t i = 0; i < t->capacity; i++) {
+        if (!t->entries[i].valid) continue;
+
+        if (now - t->entries[i].update_at < (time_t)ARP_TIMEOUT_SEC) continue;
+
+        /* Mark the slot empty, then rehash the cluster that follows it.
+         *
+         * Why: open-addressing lookup stops at the first empty slot. If we
+         * blank a slot in the middle of the chain, entries probed past it become
+         * unreachable. We fix this by shifting each subsequent entry in the same
+         * cluster back into its natural position.
+        */
+        t->entries[i].valid = false;
+        evicted++;
+
+        size_t hole = i;
+        size_t j    = (i + 1) & (t->capacity - 1);
+
+        while(t->entries[j].valid) {
+            /* Where is this entry ideally? */
+            size_t ideal = t->entries[j].ip & (t->capacity - 1);
+
+            /* If `ideal` falls in (hole..j], moving it to `hole`
+             * keeps it at or before its ideal slot.
+            */
+            bool should_move;
+            if (hole <= j) {
+                should_move = (ideal <= hole) || (ideal > j);
+            } else {
+                /* Probe chain wrapped around the end of the array. */
+                should_move = (ideal <= hole) && (ideal > j);
+            }
+
+            if (should_move) {
+                t->entries[hole] = t->entries[j];
+                t->entries[j].valid = false;
+                hole = j;
+            }
+
+            j = (j + 1) & (t->capacity - 1);
+
+            /* An empty slot marks the end of this cluster. */
+            if (!t->entries[j].valid) break;
+        }
+    }
+
+    pthread_rwlock_unlock(&t->lock);
+    return evicted;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -22,6 +22,8 @@
 #include "upe.h"
 #include "worker.h"
 
+#define NEIGHBOUR_SWEEP_INTERVAL_SEC 300
+
 volatile sig_atomic_t g_stop = 0;
 volatile sig_atomic_t g_reload = 0;
 
@@ -178,6 +180,8 @@ typedef struct {
     const rule_table_t *rt;
     int core_id;
     const char *rules_file;
+    arp_table_t *arpt;
+    ndp_table_t *ndpt;
 } stats_ctx_t;
 
 static void *stats_thread_func(void *arg) {
@@ -193,6 +197,21 @@ static void *stats_thread_func(void *arg) {
 
     while (!g_stop) {
         sleep(1); /* Stats thread wakes up every second. */
+
+        /* Sweep the ARP and NDP tables for stale entries once per
+         * NEIGHBOUR_SWEEP_INTERVAL_SEC seconds. Each table applies its own
+         * timeout (ARP_TIMEOUT_SEC / NDP_TIMEOUT_SEC) internally.
+        */
+        static int expire_ticks = 0;
+        if (++expire_ticks >= NEIGHBOUR_SWEEP_INTERVAL_SEC) {
+            expire_ticks = 0;
+            time_t now = time(NULL);
+            size_t a = arp_expire(ctx->arpt, now);
+            size_t n = ndp_expire(ctx->ndpt, now);
+            if (a || n) {
+                log_msg(LOG_INFO, "Neighbour expiry: removed %zu ARP, %zu NDP entries", a, n);
+            }
+        }
 
         if (g_reload) {
             g_reload = 0;
@@ -457,9 +476,11 @@ int main(int argc, char **argv) {
     pthread_t stats_th;
     stats_ctx_t stats_ctx = {.workers = workers,
                              .num_workers = WORKERS_NUM,
-                             .rt = rt,
-                             .core_id = stats_core,
-                             .rules_file = cfg.rules_file};
+                             .rt          = rt,
+                             .core_id     = stats_core,
+                             .rules_file  = cfg.rules_file,
+                             .apt         = &arpt,
+                             .ndpt.       = &ndpt};
     pthread_create(&stats_th, NULL, stats_thread_func, &stats_ctx);
 
     rx_start(&rx);

--- a/src/main.c
+++ b/src/main.c
@@ -22,6 +22,8 @@
 #include "upe.h"
 #include "worker.h"
 
+#define NEIGHBOUR_SWEEP_INTERVAL_SEC 300
+
 volatile sig_atomic_t g_stop = 0;
 volatile sig_atomic_t g_reload = 0;
 
@@ -178,6 +180,8 @@ typedef struct {
     const rule_table_t *rt;
     int core_id;
     const char *rules_file;
+    arp_table_t *arpt;
+    ndp_table_t *ndpt;
 } stats_ctx_t;
 
 static void *stats_thread_func(void *arg) {
@@ -193,6 +197,21 @@ static void *stats_thread_func(void *arg) {
 
     while (!g_stop) {
         sleep(1); /* Stats thread wakes up every second. */
+
+        /* Sweep the ARP and NDP tables for stale entries once per
+         * NEIGHBOUR_SWEEP_INTERVAL_SEC seconds. Each table applies its own
+         * timeout (ARP_TIMEOUT_SEC / NDP_TIMEOUT_SEC) internally.
+        */
+        static int expire_ticks = 0;
+        if (++expire_ticks >= NEIGHBOUR_SWEEP_INTERVAL_SEC) {
+            expire_ticks = 0;
+            time_t now = time(NULL);
+            size_t a = arp_expire(ctx->arpt, now);
+            size_t n = ndp_expire(ctx->ndpt, now);
+            if (a || n) {
+                log_msg(LOG_INFO, "Neighbour expiry: removed %zu ARP, %zu NDP entries", a, n);
+            }
+        }
 
         if (g_reload) {
             g_reload = 0;
@@ -457,9 +476,11 @@ int main(int argc, char **argv) {
     pthread_t stats_th;
     stats_ctx_t stats_ctx = {.workers = workers,
                              .num_workers = WORKERS_NUM,
-                             .rt = rt,
-                             .core_id = stats_core,
-                             .rules_file = cfg.rules_file};
+                             .rt          = rt,
+                             .core_id     = stats_core,
+                             .rules_file  = cfg.rules_file,
+                             .arpt        = &arpt,
+                             .ndpt        = &ndpt};
     pthread_create(&stats_th, NULL, stats_thread_func, &stats_ctx);
 
     rx_start(&rx);

--- a/src/main.c
+++ b/src/main.c
@@ -24,6 +24,8 @@
 
 #define NEIGHBOUR_SWEEP_INTERVAL_SEC 300
 
+#define NEIGHBOUR_SWEEP_INTERVAL_SEC 300
+
 volatile sig_atomic_t g_stop = 0;
 volatile sig_atomic_t g_reload = 0;
 
@@ -197,6 +199,21 @@ static void *stats_thread_func(void *arg) {
 
     while (!g_stop) {
         sleep(1); /* Stats thread wakes up every second. */
+
+        /* Sweep the ARP and NDP tables for stale entries once per
+         * NEIGHBOUR_SWEEP_INTERVAL_SEC seconds. Each table applies its own
+         * timeout (ARP_TIMEOUT_SEC / NDP_TIMEOUT_SEC) internally.
+        */
+        static int expire_ticks = 0;
+        if (++expire_ticks >= NEIGHBOUR_SWEEP_INTERVAL_SEC) {
+            expire_ticks = 0;
+            time_t now = time(NULL);
+            size_t a = arp_expire(ctx->arpt, now);
+            size_t n = ndp_expire(ctx->ndpt, now);
+            if (a || n) {
+                log_msg(LOG_INFO, "Neighbour expiry: removed %zu ARP, %zu NDP entries", a, n);
+            }
+        }
 
         /* Sweep the ARP and NDP tables for stale entries once per
          * NEIGHBOUR_SWEEP_INTERVAL_SEC seconds. Each table applies its own

--- a/src/main.c
+++ b/src/main.c
@@ -24,8 +24,6 @@
 
 #define NEIGHBOUR_SWEEP_INTERVAL_SEC 300
 
-#define NEIGHBOUR_SWEEP_INTERVAL_SEC 300
-
 volatile sig_atomic_t g_stop = 0;
 volatile sig_atomic_t g_reload = 0;
 

--- a/src/main.c
+++ b/src/main.c
@@ -24,6 +24,8 @@
 
 #define NEIGHBOUR_SWEEP_INTERVAL_SEC 300
 
+#define NEIGHBOUR_SWEEP_INTERVAL_SEC 300
+
 volatile sig_atomic_t g_stop = 0;
 volatile sig_atomic_t g_reload = 0;
 

--- a/src/ndp_table.c
+++ b/src/ndp_table.c
@@ -84,3 +84,47 @@ bool ndp_get_mac(ndp_table_t *t, const uint8_t *ip, uint8_t *out_mac) {
     pthread_rwlock_unlock(&t->lock);
     return false;
 }
+
+size_t ndp_expire(ndp_table_t *t, time_t now) {
+    if (!t) return 0;
+
+    size_t evicted = 0;
+
+    pthread_rwlock_wrlock(&t->lock);
+
+    for (size_t i = 0; i < t->capacity; i++) {
+        if (!t->entries[i].valid) continue;
+
+        if (now - t->entries[i].update_at < (time_t)NDP_TIMEOUT_SEC) continue;
+
+        t->entries[i].valid = false;
+        evicted++;
+
+        size_t hole = i;
+        size_t j    = (i + 1) & (t->capacity - 1);
+
+        while (t->entries[j].valid) {
+            size_t ideal = hash_ipv6(t->entries[j].ip, t->capacity);
+
+            bool should_move;
+            if (hole <= j) {
+                should_move = (ideal <= hole) || (ideal > j);
+            } else {
+                should_move = (ideal <= hole) && (ideal > j);
+            }
+
+            if (should_move) {
+                t->entries[hole] = t->entries[j];
+                t->entries[j].valid = false;
+                hole = j;
+            }
+
+            j = (j + 1) & (t->capacity - 1);
+
+            if (!t->entries[j].valid) break;
+        }
+    }
+
+    pthread_rwlock_unlock(&t->lock);
+    return evicted;
+}

--- a/tests/test_suite.c
+++ b/tests/test_suite.c
@@ -436,6 +436,89 @@ int test_ndp_table(void) {
     return 0;
 }
 
+// --- ARP expiry tests ---
+int test_arp_expiry(void) {
+    arp_table_t arpt;
+    TEST_ASSERT(arp_table_init(&arpt, 16) == 0);
+
+    uint32_t ip1 = 0x0A000001;
+    uint32_t ip2 = 0x0A000002;
+    uint8_t mac1[6] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06};
+    uint8_t mac2[6] = {0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f};
+
+    arp_update(&arpt, ip1, mac1);
+    arp_update(&arpt, ip2, mac2);
+
+    // Test 1) Nothing expires when called right after insertion.
+    size_t evicted = arp_expire(&arpt, time(NULL));
+    TEST_ASSERT(evicted == 0);
+
+    uint8_t out[6];
+    TEST_ASSERT(arp_get_mac(&arpt, ip1, out) == true);
+    TEST_ASSERT(arp_get_mac(&arpt, ip2, out) == true);
+
+    // Test 2) Backdate ip1's timestamp to simulate expired.
+    size_t idx1 = ip1 & (arpt.capacity - 1);
+    for (size_t i = 0; i < arpt.capacity; i++) {
+        size_t s = (idx1 + i) & (arpt.capacity - 1);
+        if (arpt.entries[s].valid && arpt.entries[s].ip == ip1) {
+            arpt.entries[s].update_at -= (ARP_TIMEOUT_SEC + 1);
+            break;
+        }
+    }
+
+    evicted = arp_expire(&arpt, time(NULL));
+    TEST_ASSERT(evicted == 1);
+
+    // ip1 should be gone, ip2 not.
+    TEST_ASSERT(arp_get_mac(&arpt, ip1, out) == false);
+    TEST_ASSERT(arp_get_mac(&arpt, ip2, out) == true);
+    TEST_ASSERT(memcmp(out, mac2, 6) == 0);
+
+    arp_table_destroy(&arpt);
+    return 0;
+}
+
+// --- NDP expiry tests ---
+int test_ndp_expiry(void) {
+    ndp_table_t t;
+    TEST_ASSERT(ndp_table_init(&t, 16) == 0);
+
+    uint8_t ip1[16] = {0x20,0x01,0x0d,0xb8,0,0,0,0,0,0,0,0,0,0,0,1};
+    uint8_t ip2[16] = {0x20,0x01,0x0d,0xb8,0,0,0,0,0,0,0,0,0,0,0,2};
+    uint8_t mac1[6] = {0xaa,0xbb,0xcc,0xdd,0xee,0xff};
+    uint8_t mac2[6] = {0x11,0x22,0x33,0x44,0x55,0x66};
+
+    ndp_update(&t, ip1, mac1);
+    ndp_update(&t, ip2, mac2);
+
+    // Test 1) Should not expire immediately.
+    size_t evicted = ndp_expire(&t, time(NULL));
+    TEST_ASSERT(evicted == 0);
+
+    uint8_t out[6];
+    TEST_ASSERT(ndp_get_mac(&t, ip1, out) == true);
+    TEST_ASSERT(ndp_get_mac(&t, ip2, out) == true);
+
+    // Test 2) Backdate ip1's timestamp to simulate expired.
+    for (size_t i = 0; i < t.capacity; i++) {
+        if (t.entries[i].valid && memcmp(t.entries[i].ip, ip1, 16) == 0) {
+            t.entries[i].update_at -= (NDP_TIMEOUT_SEC + 1);
+            break;
+        }
+    }
+
+    evicted = ndp_expire(&t, time(NULL));
+    TEST_ASSERT(evicted == 1);
+
+    TEST_ASSERT(ndp_get_mac(&t, ip1, out) == false);
+    TEST_ASSERT(ndp_get_mac(&t, ip2, out) == true);
+    TEST_ASSERT(memcmp(out, mac2, 6) == 0);
+
+    ndp_table_destroy(&t);
+    return 0;
+}
+
 // --- IPv6 Rule Matching related tests ---
 int test_ipv6_rule_matching(void) {
     rule_table_t rt;
@@ -561,6 +644,8 @@ int main(void) {
     RUN_TEST(test_pktbuf_pool);
     RUN_TEST(test_arp_table);
     RUN_TEST(test_ndp_table);
+    RUN_TEST(test_arp_expiry);
+    RUN_TEST(test_ndp_expiry);
     RUN_TEST(test_ipv6_rule_matching);
     RUN_TEST(test_rule_config_load);
     return 0;


### PR DESCRIPTION
ARP_TIMEOUT_SEC was unused so far. Added a matching NDP_TIMEOUT_SEC and implemented arp_expire() and ndp_expire() to evict timed out entries and rehash the probe cluster to avoid breaking the open-addressing lookup.

Stats thread will be responsible for sweeping the tables every NEIGHBOUR_SWEEP_INTERVAL_SEC seconds.

Closes #36 