### PR TITLE
test: create mock DPDK forwarding test suite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,15 +117,40 @@ target_link_options(upe-router PRIVATE
 )
 
 # Router testing
-add_executable(bench-mac-table
+add_executable(bench_mac_table
   router/bench/bench_mac_table.c
   router/src/mac_table.c
 )
 
-target_include_directories(bench-mac-table PRIVATE
+target_include_directories(bench_mac_table PRIVATE
   include
   router/include
   ${DPDK_INCLUDE_DIRS}
 )
 
-set_target_properties(bench-mac-table PROPERTIES C_EXTENSIONS ON)
+set_target_properties(bench_mac_table PROPERTIES C_EXTENSIONS ON)
+
+add_test(NAME Router_Bench_Mac_Table COMMAND bench_mac_table)
+set_tests_properties(Router_Bench_Mac_Table PROPERTIES LABELS "Benchmark")
+
+add_executable(test_forwarding
+  router/bench/test_forwarding.c
+  router/src/mac_table.c
+  src/latency.c
+  src/log.c
+)
+
+target_include_directories(test_forwarding PRIVATE
+  include
+  router/include
+  router/bench
+  ${DPDK_INCLUDE_DIRS}
+)
+
+target_link_libraries(test_forwarding PRIVATE
+  pthread
+  m
+)
+
+add_test(NAME Router_Forwarding_Tests COMMAND test_forwarding)
+set_tests_properties(Router_Forwarding_Tests PROPERTIES LABELS "Unit")

--- a/router/bench/mock_dpdk.h
+++ b/router/bench/mock_dpdk.h
@@ -1,0 +1,137 @@
+#ifndef MOCK_DPDK_H
+#define MOCK_DPDK_H
+
+/* Redirect rdtsc to an ignored name */
+#define rdtsc hardware_rdtsc_ignored
+
+/* Force latency.h (which defined rdtsc()) to load. It will define hardware_rdtsc_ignored instead. */
+#include "latency.h"
+
+/* Undefine the redirection so we can use the clean rdtsc name */
+#undef rdtsc
+
+/* Header guard intercept so rx_lcore.c won't try to find DPDK system headers */
+#define _RTE_EAL_H_
+#define _RTE_ETHDEV_H_
+#define _RTE_ETHER_H_
+#define _RTE_MBUF_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define MAC_ADDR_LEN 6
+#define RTE_PKTMBUF_HEADROOM 128
+#define NUM_PORTS 2
+#define BURST_SIZE 32
+#define MOCK_MBUF_SIZE 2048
+
+/* Ethernet header definition (rte_ether.h) */
+struct rte_ether_addr {
+    uint8_t addr_bytes[6];
+};
+
+struct rte_ether_hdr {
+    struct rte_ether_addr dst_addr;
+    struct rte_ether_addr src_addr;
+    uint16_t ether_type;
+} __attribute__((__packed__));
+
+/* Fake DPDK mbuf structure */
+struct rte_mbuf {
+    uint32_t pkt_len;
+    uint16_t data_len;
+    uint16_t port;
+    void *buf_addr;
+    void *pool;
+    char data_buf[MOCK_MBUF_SIZE];
+};
+
+/* Mock macro to get data pointer and cast it to the requested type */
+#define rte_pktmbuf_mtod(m, t) ((t)((char *)(m)->buf_addr))
+
+/* Global counters */
+extern uint32_t mock_mbuf_allocated;
+extern uint32_t mock_mbuf_freed;
+
+/* Mock DPDK memory management */
+static inline struct rte_mbuf *rte_pktmbuf_alloc(void *pool) {
+    (void)pool;
+    struct rte_mbuf *m = (struct rte_mbuf *)malloc(sizeof(struct rte_mbuf));
+    if (m) {
+        memset(m, 0, sizeof(struct rte_mbuf));
+        m->buf_addr = m->data_buf + RTE_PKTMBUF_HEADROOM;
+        m->pool = pool;
+        mock_mbuf_allocated++;
+    }
+    return m;
+}
+
+static inline void rte_pktmbuf_free(struct rte_mbuf *m) {
+    if (m) {
+        mock_mbuf_freed++;
+        free(m);
+    }
+}
+
+static inline struct rte_mbuf *rte_pktmbuf_copy(const struct rte_mbuf *m, void *pool, uint32_t offset, uint32_t length) {
+    (void)offset;
+    (void)length;
+    if (!m) return NULL;
+    struct rte_mbuf *clone = rte_pktmbuf_alloc(pool);
+    if (clone) {
+        clone->pkt_len = m->pkt_len;
+        clone->data_len = m->data_len;
+        clone->port = m->port;
+        memcpy(clone->data_buf, m->data_buf, sizeof(m->data_buf));
+    }
+    return clone;
+}
+
+/* Helper to build test packets */
+static inline struct rte_mbuf *mock_build_packet(uint16_t port, const uint8_t *src_mac, const uint8_t *dst_mac, uint16_t ethertype) {
+    struct rte_mbuf *m = rte_pktmbuf_alloc(NULL);
+    if (!m) return NULL;
+
+    m->port = port;
+    uint8_t *pkt = (uint8_t *)m->buf_addr;
+
+    memcpy(pkt, dst_mac, 6);
+    memcpy(pkt + 6, src_mac, 6);
+    pkt[12] = (ethertype >> 8) & 0xFF;
+    pkt[13] = ethertype & 0xFF;
+
+    m->data_len = 14;
+    m->pkt_len = 14;
+    return m;
+}
+
+static inline uint64_t rdtsc(void) {
+    static uint64_t mock_tsc = 1000000;
+    return mock_tsc++;
+}
+
+/* Mock that the NIC hardware accepted the packets */
+static inline uint16_t rte_eth_tx_burst(uint16_t port_id, uint16_t queue_id, struct rte_mbuf **tx_pkts, uint16_t nb_pkts) {
+    (void)port_id;
+    (void)queue_id;
+    (void)tx_pkts;
+    return nb_pkts; /* Pretend all were successfully transmitted */
+}
+
+/* Mock lcore utility */
+static inline unsigned int rte_lcore_id(void) {
+    return 0;
+}
+
+/* Mock RX burst function */
+static inline uint16_t rte_eth_rx_burst(uint16_t port_id, uint16_t queue_id, struct rte_mbuf **rx_pkts, uint16_t nb_pkts) {
+    (void)port_id;
+    (void)queue_id;
+    (void)rx_pkts;
+    (void)nb_pkts;
+    return 0;
+}
+
+#endif // MOCK_DPDK_H

--- a/router/bench/test_forwarding.c
+++ b/router/bench/test_forwarding.c
@@ -1,0 +1,119 @@
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "mock_dpdk.h"
+
+#include "../src/rx_lcore.c"
+
+uint32_t mock_mbuf_allocated = 0;
+uint32_t mock_mbuf_freed = 0;
+
+static int g_tests_run = 0;
+static int g_tests_passed = 0;
+static int g_tests_failed = 0;
+
+#define ASSERT(cond, msg)                                                                          \
+    do {                                                                                           \
+        g_tests_run++;                                                                             \
+        if (cond) {                                                                                \
+            g_tests_passed++;                                                                      \
+        } else {                                                                                   \
+            g_tests_failed++;                                                                      \
+            fprintf(stderr, "FAIL [%s:%d] %s\n", __FILE__, __LINE__, msg);                         \
+        }                                                                                          \
+    } while (0)
+
+/* Test data */
+static const uint8_t MAC_HOST_A[6] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x0A};
+static const uint8_t MAC_HOST_B[6] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x0B};
+static const uint8_t MAC_BROADCAST[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+
+static void setup_ctx(rx_lcore_ctx_t *ctx) {
+    memset(ctx, 0, sizeof(rx_lcore_ctx_t));
+    mac_table_init(&ctx->mac_table, 30, 2.0);
+    ctx->cycles_per_ns = 2.0;
+}
+
+static void test_mac_learning_and_flooding() {
+    rx_lcore_ctx_t ctx;
+    setup_ctx(&ctx);
+
+    /* Host A (Port 0) sends a packet to Host B (Unknown port) */
+    struct rte_mbuf *pkt = mock_build_packet(0, MAC_HOST_A, MAC_HOST_B, 0x0800);
+
+    /* Process the packet */
+    forward_mbuf(&ctx, pkt, 0, rdtsc());
+
+    uint16_t learned_port;
+    bool found = mac_table_lookup(&ctx.mac_table, MAC_HOST_A, rdtsc(), &learned_port);
+
+    ASSERT(found == true, "MAC Table should have learned Host A's MAC");
+    ASSERT(learned_port == 0, "Host A's MAC should be mapped to Port 0");
+
+    /* Because Host B was unknown, it should have flooded to Port 1 */
+    ASSERT(ctx.packets_flooded == 1, "Packet to unknown MAC should trigger flood");
+    ASSERT(ctx.tx_buffers[1].count == 1, "Packet should be in Port 1's TX queue");
+    ASSERT(ctx.tx_buffers[0].count == 0, "Packet shouldn't be in Port 0's TX queue");
+}
+
+static void test_unicast_forwarding() {
+    rx_lcore_ctx_t ctx;
+    setup_ctx(&ctx);
+
+    /* Populate MAC table with Host B on Port 1 */
+    mac_table_insert(&ctx.mac_table, MAC_HOST_B, 1, rdtsc());
+
+    /* Host A (Port 0) sends a packet to Host B */
+    struct rte_mbuf *pkt = mock_build_packet(0, MAC_HOST_A, MAC_HOST_B, 0x0800);
+
+    forward_mbuf(&ctx, pkt, 0, rdtsc());
+
+    ASSERT(ctx.packets_forwarded == 1, "Packet should be unicast forwarded, not flooded");
+    ASSERT(ctx.packets_flooded == 0, "Packet shouldn't be flooded");
+    ASSERT(ctx.tx_buffers[1].count == 1, "Packet should be in Port 1's TX queue");
+}
+
+static void test_broadcast_flooding() {
+    rx_lcore_ctx_t ctx;
+    setup_ctx(&ctx);
+
+    /* Host A (Port 0) sends an ARP Broadcast */
+    struct rte_mbuf *pkt = mock_build_packet(0, MAC_HOST_A, MAC_BROADCAST, 0x0806);
+
+    forward_mbuf(&ctx, pkt, 0, rdtsc());
+
+    ASSERT(ctx.packets_flooded == 1, "Broadcast packet must be flooded");
+    ASSERT(ctx.tx_buffers[1].count == 1, "Broadcast copy should go to Port 1");
+}
+
+static void test_hairpin_drop() {
+    rx_lcore_ctx_t ctx;
+    setup_ctx(&ctx);
+
+    /* Host A is on Port 0 */
+    mac_table_insert(&ctx.mac_table, MAC_HOST_A, 0, rdtsc());
+
+    /* Something on Port 0 sends a packet to Host A */
+    struct rte_mbuf *pkt = mock_build_packet(0, MAC_HOST_B, MAC_HOST_A, 0x0800);
+
+    forward_mbuf(&ctx, pkt, 0, rdtsc());
+
+    ASSERT(ctx.packets_dropped == 1, "Packet should be dropped if ingress == egress port");
+    ASSERT(ctx.tx_buffers[0].count == 0, "Packet shouldn't be queued for transmission");
+}
+
+int main() {
+    printf("Running Forwarding Tests...\n");
+    printf("--------------------------------------------------\n");
+
+    test_mac_learning_and_flooding();
+    test_unicast_forwarding();
+    test_broadcast_flooding();
+    test_hairpin_drop();
+
+    printf("\nResults: %d Passed, %d Failed\n", g_tests_passed, g_tests_failed);
+
+    return g_tests_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
New test suite for the router forwarding logic. It mocks the DPDK environment so it doesn't depend on the hardware.

Also added the router benchmark and unit tests to ctest with separate labels.