### PR TITLE
tests: add rx_lcore forwarding integration tests and malformed packet…

### DIFF
--- a/router/bench/bench_mac_table.c
+++ b/router/bench/bench_mac_table.c
@@ -346,10 +346,7 @@ int main(void) {
     test_entry_refresh();
     test_ignore_non_unicast_sources();
     test_table_saturation_and_probe_limit();
-<<<<<<< HEAD
     test_transparent_overwrite_stability();
-=======
->>>>>>> 3e793a3ec9961a51ad21fc992f57578cfd4d34aa
 
     printf("\nTest Execution Summary:\n");
     printf("  Total Assertions Run: %d\n", g_tests_run);

--- a/router/bench/test_forwarding.c
+++ b/router/bench/test_forwarding.c
@@ -104,6 +104,70 @@ static void test_hairpin_drop() {
     ASSERT(ctx.tx_buffers[0].count == 0, "Packet shouldn't be queued for transmission");
 }
 
+static void test_system_mac_migration() {
+    rx_lcore_ctx_t ctx;
+    setup_ctx(&ctx);
+
+    /* Host A sends a packet on Port 0 to Host B */
+    struct rte_mbuf *pkt1 = mock_build_packet(0, MAC_HOST_A, MAC_HOST_B, 0x0800);
+    forward_mbuf(&ctx, pkt1, 0, rdtsc());
+
+    /* Snapshot the counters before the reply */
+    uint32_t prev_forwarded = ctx.packets_forwarded;
+    uint32_t prev_flooded = ctx.packets_flooded;
+
+    /* Host B replies to Host A from Port 1 */
+    struct rte_mbuf *pkt2 = mock_build_packet(1, MAC_HOST_B, MAC_HOST_A, 0x0800);
+    forward_mbuf(&ctx, pkt2, 1, rdtsc());
+
+    /* Verify the reply was unicast to Port 0 */
+    ASSERT(ctx.tx_buffers[0].count == 1, "Reply should be in Port 0's TX queue");
+    ASSERT(ctx.packets_forwarded == prev_forwarded + 1,
+           "Reply must increment unicast forwarded count");
+    ASSERT(ctx.packets_flooded == prev_flooded, "Reply must not increment flooded count");
+
+    /* Reset buffers and snapshot counters for the port migration */
+    ctx.tx_buffers[0].count = 0;
+    ctx.tx_buffers[1].count = 0;
+    prev_forwarded = ctx.packets_forwarded;
+    prev_flooded = ctx.packets_flooded;
+
+    /* Host A unplugs and sends a packet from Port 1 now */
+    struct rte_mbuf *pkt3 = mock_build_packet(1, MAC_HOST_A, MAC_HOST_B, 0x0800);
+    forward_mbuf(&ctx, pkt3, 1, rdtsc());
+
+    ASSERT(ctx.packets_dropped == 1, "Pkt3 should be a hairpin drop");
+
+    /* Host B unplugs and sends a packet from Port 0 to Host A */
+    struct rte_mbuf *pkt4 = mock_build_packet(0, MAC_HOST_B, MAC_HOST_A, 0x0800);
+    forward_mbuf(&ctx, pkt4, 0, rdtsc());
+
+    /* Verify the reply was unicast unicast to Port 1 */
+    ASSERT(ctx.tx_buffers[1].count == 1, "Last reply must be in Port 1's TX queue");
+    ASSERT(ctx.packets_forwarded == prev_forwarded + 1,
+           "Only pkt4 should successfully unicast forward");
+    ASSERT(ctx.packets_flooded == prev_flooded, "No packets should be flooded");
+}
+
+static void test_system_malformed_packet_drop() {
+    rx_lcore_ctx_t ctx;
+    setup_ctx(&ctx);
+
+    struct rte_mbuf *bad_pkt = rte_pktmbuf_alloc(NULL);
+    ASSERT(bad_pkt != NULL, "Mbuf allocation failed");
+
+    bad_pkt->port = 0;
+    bad_pkt->data_len = 10; /* Doesn't reach the minimum 14 byte Eth header */
+    bad_pkt->pkt_len = 10;
+
+    uint32_t freed_before = mock_mbuf_freed;
+
+    forward_mbuf(&ctx, bad_pkt, 0, rdtsc());
+
+    ASSERT(ctx.packets_dropped == 1, "Malformed frame should be dropped");
+    ASSERT(mock_mbuf_freed == freed_before + 1, "Malformed frame buffer must be released");
+}
+
 int main() {
     printf("Running Forwarding Tests...\n");
     printf("--------------------------------------------------\n");
@@ -112,6 +176,8 @@ int main() {
     test_unicast_forwarding();
     test_broadcast_flooding();
     test_hairpin_drop();
+    test_system_mac_migration();
+    test_system_malformed_packet_drop();
 
     printf("\nResults: %d Passed, %d Failed\n", g_tests_passed, g_tests_failed);
 


### PR DESCRIPTION
… check

Added some integration tests in test_forwarding.c to cover the unicast forwarding, broadcast flooding, hairpin drops, host MAC moves and malformed frames

In the prod code there was a change as well, we check the frame length in forward_mbuf to discard frames that are too long for an Ethernet frame.