### PR TITLE
feat: Create UPE DPDK Router L3 capabilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,8 @@ pkg_check_modules(DPDK REQUIRED libdpdk)
 add_executable(upe-router
   router/src/main.c
   router/src/mac_table.c
+  router/src/lpm.c
+  router/src/arp4.c
   router/src/rx_lcore.c
   src/latency.c
   src/log.c
@@ -102,6 +104,7 @@ target_compile_options(upe-router PRIVATE
   -Wall
   -Wextra
   -Wno-pedantic
+  -D_DEFAULT_SOURCE
 )
 
 target_link_libraries(upe-router PRIVATE
@@ -136,6 +139,8 @@ set_tests_properties(Router_Bench_Mac_Table PROPERTIES LABELS "Benchmark")
 add_executable(test_forwarding
   router/bench/test_forwarding.c
   router/src/mac_table.c
+  router/src/lpm.c
+  router/src/arp4.c
   src/latency.c
   src/log.c
 )

--- a/router/bench/mock_dpdk.h
+++ b/router/bench/mock_dpdk.h
@@ -15,6 +15,11 @@
 #define _RTE_ETHDEV_H_
 #define _RTE_ETHER_H_
 #define _RTE_MBUF_H_
+#define _RTE_IP_H_
+#define _RTE_ARP_H_
+#define _RTE_BYTEORDER_H_
+#define _RTE_BYTEORDER_X86_H_
+#define _RTE_BYTEORDER_ARM_H_
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -160,5 +165,55 @@ static inline uint16_t rte_eth_rx_burst(uint16_t port_id, uint16_t queue_id, str
     (void)nb_pkts;
     return 0;
 }
+
+/* L3 DPDK MOCKS */
+#define rte_pktmbuf_mtod_offset(m, t, o) ((t)((char *)(m)->buf_addr + (o)))
+#define rte_be_to_cpu_16(x) (x)
+#define rte_be_to_cpu_32(x) (x)
+#define rte_cpu_to_be_16(x) (x)
+#define rte_cpu_to_be_32(x) (x)
+
+#define RTE_ETHER_TYPE_IPV4 0x0800
+#define RTE_ETHER_TYPE_ARP  0x0806
+#define RTE_ARP_HRD_ETHER 1
+#define RTE_ARP_OP_REQUEST 1
+#define RTE_ARP_OP_REPLY   2
+
+static inline void rte_ether_addr_copy(const struct rte_ether_addr *ea_from, struct rte_ether_addr *ea_to) {
+    *ea_to = *ea_from;
+}
+
+struct rte_ipv4_hdr {
+    uint8_t  version_ihl;
+    uint8_t  type_of_service;
+    uint16_t total_length;
+    uint16_t packet_id;
+    uint16_t fragment_offset;
+    uint8_t  time_to_live;
+    uint8_t  next_proto_id;
+    uint16_t hdr_checksum;
+    uint32_t src_addr;
+    uint32_t dst_addr;
+} __attribute__((__packed__));
+
+static inline uint16_t rte_ipv4_cksum(const struct rte_ipv4_hdr *ipv4_hdr) {
+    (void)ipv4_hdr; return 0;
+}
+
+struct rte_arp_ipv4 {
+    struct rte_ether_addr arp_sha;
+    uint32_t              arp_sip;
+    struct rte_ether_addr arp_tha;
+    uint32_t              arp_tip;
+} __attribute__((__packed__));
+
+struct rte_arp_hdr {
+    uint16_t arp_hardware;
+    uint16_t arp_protocol;
+    uint8_t  arp_hlen;
+    uint8_t  arp_plen;
+    uint16_t arp_opcode;
+    struct rte_arp_ipv4 arp_data;
+} __attribute__((__packed__));
 
 #endif // MOCK_DPDK_H

--- a/router/include/arp4.h
+++ b/router/include/arp4.h
@@ -1,0 +1,27 @@
+#ifndef ARP4_H
+#define ARP4_H
+
+#include <cstdint>
+#include <stdint.h>
+#include <stdbool.h>
+
+#define ARP_TABLE_CAPACITY  512
+#define ARP_MAX_PROBES      16
+
+typedef struct {
+    uint32_t    ip;     /* Network byte order key */
+    uint8_t     mac[6]; /* Resolved value */
+    bool        occupied;
+} arp4_entry_t;
+
+typedef struct {
+    arp4_entry_t entries[ARP_TABLE_CAPACITY];
+    uint32_t     arp_miss_count;
+} arp4_table_t;
+
+/* API Methods */
+void arp4_init(arp4_table_t *table);
+bool arp4_insert(arp4_table_t *table, uint32_t ip, const uint8_t mac[6]);
+bool arp4_lookup(arp4_table_t *table, uint32_t ip, uint8_t out_mac[6]);
+
+#endif /* ARP4_H */

--- a/router/include/arp4.h
+++ b/router/include/arp4.h
@@ -1,7 +1,6 @@
 #ifndef ARP4_H
 #define ARP4_H
 
-#include <cstdint>
 #include <stdint.h>
 #include <stdbool.h>
 

--- a/router/include/lpm.h
+++ b/router/include/lpm.h
@@ -1,0 +1,27 @@
+#ifndef LPM_H
+#define LPM_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#define LPM_TABLE_CAPACITY 1024
+
+typedef struct {
+    uint32_t    prefix;         /* Network byte order */
+    uint8_t     prefix_len;
+    uint32_t    next_hop_ip;    /* Network byte order */
+    uint16_t    egress_port;
+    bool        valid;
+} lpm_entry_t;
+
+typedef struct {
+    lpm_entry_t entries[LPM_TABLE_CAPACITY];
+    uint32_t    count;
+} lpm_table_t;
+
+/* API Methods */
+void lpm_init(lpm_table_t *table);
+bool lpm_insert(lpm_table_t *table, uint32_t prefix, uint8_t prefix_len, uint32_t next_hop_ip, uint16_t egress_port);
+bool lpm_lookup(const lpm_table_t *table, uint32_t dest_ip, uint32_t *out_next_hop, uint16_t *out_port);
+
+#endif /* LPM_H */

--- a/router/include/router.h
+++ b/router/include/router.h
@@ -29,6 +29,14 @@ typedef struct {
     uint32_t link_wait_sec;
 } router_config_t;
 
+/* Router Interface configuration per port */
+typedef struct {
+    uint32_t ip;        /* Network byte order */
+    uint32_t netmask;   /* Network byte order */
+    uint8_t mac[6];     /* Source MAC for egress on this port */
+    bool configured;
+} router_iface_t;
+
 /* Per-port TX burst buffer */
 typedef struct {
     struct rte_mbuf *mbufs[BURST_SIZE];
@@ -38,13 +46,24 @@ typedef struct {
 /* RX lcore context (worker thread data) */
 typedef struct {
     mac_table_t mac_table;
-    latency_histogram_t latency_hist[NUM_PORTS];
+    lpm_table_t lpm;
+    arp4_table_t arp4;
+    router_iface_t ifaces[NUM_PORTS];
+
     tx_buffer_t tx_buffers[NUM_PORTS];
+    latency_histogram_t latency_hist[NUM_PORTS];
+
     uint64_t packets_forwarded;
     uint64_t bytes_forwarded;
     uint64_t packets_flooded;
     uint64_t packets_dropped;
     uint64_t pool_exhaustion_count;
+    uint64_t packets_routed;
+    uint64_t packets_ttl_exceeded;
+    uint64_t packets_no_route;
+    uint64_t packets_arp_miss;
+    uint64_t packets_local;
+
     double cycles_per_ns;
     volatile bool stop;
 } rx_lcore_ctx_t;

--- a/router/include/router.h
+++ b/router/include/router.h
@@ -5,6 +5,8 @@
 #include <stdbool.h>
 #include <rte_mbuf.h>
 #include "mac_table.h"
+#include "lpm.h"
+#include "arp4.h"
 #include "latency.h"
 
 #define NUM_PORTS 2

--- a/router/src/arp4.c
+++ b/router/src/arp4.c
@@ -1,0 +1,64 @@
+#include "arp4.h"
+#include <string.h>
+
+#define FNV_OFFSET_BASIS 2166136261u
+#define FNV_PRIME 16777619u
+
+/* 32-bit FNV-1a hash function on a 4-byte IPv4 input */
+static inline uint32_t hash_ipv4(uint32_t ip) {
+    uint32_t hash = FNV_OFFSET_BASIS;
+    const uint8_t *bytes = (const uint8_t *)&ip;
+
+    for (int i = 0; i < 4; i++) {
+        hash ^= bytes[i];
+        hash *= FNV_PRIME;
+    }
+    return hash;
+}
+
+void arp4_init(arp4_table_t *table) {
+    if (!table) return;
+    memset(table, 0, sizeof(arp4_table_t));
+}
+
+bool arp4_insert(arp4_table_t *table, uint32_t ip, const uint8_t mac[6]) {
+    if (!table || !mac) return false;
+
+    uint32_t hash = hash_ipv4(ip);
+    uint32_t base_idx = hash & (ARP_TABLE_CAPACITY - 1);
+
+    for (uint32_t i = 0; i < ARP_MAX_PROBES; i++) {
+        uint32_t idx = (base_idx + i) & (ARP_TABLE_CAPACITY - 1);
+
+        if (!table->entries[idx].occupied || table->entries[idx].ip == ip) {
+            table->entries[idx].ip = ip;
+            memcpy(table->entries[idx].mac, mac, 6);
+            table->entries[idx].occupied = true;
+            return true;
+        }
+    }
+    return false;
+}
+
+bool arp4_lookup(arp4_table_t *table, uint32_t ip, uint8_t out_mac[6]) {
+    if (!table || !out_mac) return false;
+
+    uint32_t hash = hash_ipv4(ip);
+    uint32_t base_idx = hash & (ARP_TABLE_CAPACITY - 1);
+
+    for (uint32_t i = 0; i < ARP_MAX_PROBES; i++) {
+        uint32_t idx = (base_idx + 1) & (ARP_TABLE_CAPACITY - 1);
+
+        if (!table->entries[idx].occupied) {
+            return false;
+        }
+
+        if (table->entries[idx].ip == ip) {
+            memcpy(out_mac, table->entries[idx].mac, 6);
+            return true;
+        }
+    }
+
+    table->arp_miss_count++;
+    return false;
+}

--- a/router/src/lpm.c
+++ b/router/src/lpm.c
@@ -1,0 +1,80 @@
+#include "lpm.h"
+#include <arpa/inet.h>
+#include <string.h>
+
+static inline uint32_t compute_mask(uint8_t prefix_len) {
+    /* Prevent shift by 32 (undefined behavior) */
+    if (prefix_len == 0) {
+        return 0;
+    }
+    // ~0u is all 1s
+    return htonl(~0u << (32 - prefix_len));
+}
+
+void lpm_init(lpm_table_t *table) {
+    if (!table) return;
+    memset(table, 0, sizeof(lpm_table_t));
+}
+
+bool lpm_insert(lpm_table_t *table, uint32_t prefix, uint8_t prefix_len, uint32_t next_hop_ip,
+                uint16_t egress_port) {
+    if (!table || prefix_len > 32) return false;
+
+    uint32_t mask = compute_mask(prefix_len);
+    uint32_t masked_prefix = prefix & mask;
+
+    /* Overwrite if there's a duplicate */
+    for (uint32_t i = 0; i < table->count; i++) {
+        if (table->entries[i].valid && table->entries[i].prefix == masked_prefix &&
+            table->entries[i].prefix_len == prefix_len) {
+            table->entries[i].next_hop_ip = next_hop_ip;
+            table->entries[i].egress_port = egress_port;
+            return true;
+        }
+    }
+
+    if (table->count >= LPM_TABLE_CAPACITY) {
+        return false;
+    }
+
+    /* Otherwise append new route */
+    uint32_t idx = table->count++;
+    table->entries[idx].prefix = masked_prefix;
+    table->entries[idx].prefix_len = prefix_len;
+    table->entries[idx].next_hop_ip = next_hop_ip;
+    table->entries[idx].egress_port = egress_port;
+    table->entries[idx].valid = true;
+
+    return true;
+}
+
+bool lpm_lookup(const lpm_table_t *table, uint32_t dest_ip, uint32_t *out_next_hop,
+                uint16_t *out_port) {
+    if (!table || !out_next_hop || !out_port) return false;
+
+    int best_match_idx = -1;
+    int max_prefix_len = -1;
+
+    /* Linear scan to get the longest active subnetwork match */
+    for (uint32_t i = 0; i < table->count; i++) {
+        if (!table->entries[i].valid) continue;
+
+        uint32_t mask = compute_mask(table->entries[i].prefix_len);
+
+        /* Does the destination IP fall inside the subnet block? */
+        if ((dest_ip & mask) == table->entries[i].prefix) {
+            if ((int)table->entries[i].prefix_len > max_prefix_len) {
+                max_prefix_len = table->entries[i].prefix_len;
+                best_match_idx = (int)i;
+            }
+        }
+    }
+
+    if (best_match_idx != -1) {
+        *out_next_hop = table->entries[best_match_idx].next_hop_ip;
+        *out_port = table->entries[best_match_idx].egress_port;
+        return true;
+    }
+
+    return false; /* No Route Found */
+}

--- a/router/src/rx_lcore.c
+++ b/router/src/rx_lcore.c
@@ -57,7 +57,7 @@ static void send_arp_request(rx_lcore_ctx_t *ctx, struct rte_mbuf *mbuf, uint16_
     eth->ether_type = rte_cpu_to_be_16(RTE_ETHER_TYPE_ARP);
 
     /* ARP hdr */
-    arp->arp_hardware = rte_cpu_to_be_16(RTE_ARP_HDR_ETHER);
+    arp->arp_hardware = rte_cpu_to_be_16(RTE_ARP_HRD_ETHER);
     arp->arp_protocol = rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV4);
     arp->arp_hlen = 6;
     arp->arp_plen = 4;
@@ -65,7 +65,7 @@ static void send_arp_request(rx_lcore_ctx_t *ctx, struct rte_mbuf *mbuf, uint16_
 
     rte_ether_addr_copy((const struct rte_ether_addr *)ctx->ifaces[egress_port].mac, &arp->arp_data.arp_sha);
     arp->arp_data.arp_sip = ctx->ifaces[egress_port].ip;
-    memset(&arp->arp_data.arp_tha; 0, 6);
+    memset(&arp->arp_data.arp_tha, 0, 6);
     arp->arp_data.arp_tip = target_ip;
 
     enqueue_tx(egress_port, &ctx->tx_buffers[egress_port], mbuf);

--- a/router/src/rx_lcore.c
+++ b/router/src/rx_lcore.c
@@ -2,12 +2,17 @@
 #include <rte_ethdev.h>
 #include <rte_ether.h>
 #include <rte_mbuf.h>
+#include <rte_ip.h>
+#include <rte_arp.h>
+#include <rte_byteorder.h>
 #include <string.h>
 
 #include "latency.h"
 #include "log.h"
 #include "mac_table.h"
 #include "router.h"
+#include "arp4.h"
+#include "lpm.h"
 
 /* Get pointer to the Ethernet header inside an mbuf. */
 static inline struct rte_ether_hdr *eth_hdr(struct rte_mbuf *mbuf) {
@@ -35,6 +40,156 @@ static inline void enqueue_tx(uint16_t port_id, tx_buffer_t *buf, struct rte_mbu
     if (buf->count == BURST_SIZE) flush_tx_buffer(port_id, buf);
 }
 
+/* Generate and send ARP request with existing mbuf. */
+static void send_arp_request(rx_lcore_ctx_t *ctx, struct rte_mbuf *mbuf, uint16_t egress_port,
+                             uint32_t target_ip) {
+    /* Reuse the mbuf: overwrite with ARP request. */
+    uint16_t pkt_len = sizeof(struct rte_ether_hdr) + sizeof(struct rte_arp_hdr);
+    mbuf->data_len = pkt_len;
+    mbuf->pkt_len = pkt_len;
+
+    struct rte_ether_hdr *eth = eth_hdr(mbuf);
+    struct rte_arp_hdr *arp = rte_pktmbuf_mtod_offset(mbuf, struct rte_arp_hdr *, sizeof(struct rte_ether_hdr));
+
+    /* Ethernet hdr */
+    memset(&eth->dst_addr, 0xFF, 6); /* Broadcast */
+    rte_ether_addr_copy((const struct rte_ether_addr *)ctx->ifaces[egress_port].mac, &eth->src_addr);
+    eth->ether_type = rte_cpu_to_be_16(RTE_ETHER_TYPE_ARP);
+
+    /* ARP hdr */
+    arp->arp_hardware = rte_cpu_to_be_16(RTE_ARP_HDR_ETHER);
+    arp->arp_protocol = rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV4);
+    arp->arp_hlen = 6;
+    arp->arp_plen = 4;
+    arp->arp_opcode = rte_cpu_to_be_16(RTE_ARP_OP_REQUEST);
+
+    rte_ether_addr_copy((const struct rte_ether_addr *)ctx->ifaces[egress_port].mac, &arp->arp_data.arp_sha);
+    arp->arp_data.arp_sip = ctx->ifaces[egress_port].ip;
+    memset(&arp->arp_data.arp_tha; 0, 6);
+    arp->arp_data.arp_tip = target_ip;
+
+    enqueue_tx(egress_port, &ctx->tx_buffers[egress_port], mbuf);
+}
+
+/* Handle ARP packets (requests, replies). */
+static bool handle_arp(rx_lcore_ctx_t *ctx, struct rte_mbuf *mbuf, uint16_t ingress_port, uint64_t ingress_tsc) {
+    if (!ctx->ifaces[ingress_port].configured) return false;
+
+    struct rte_ether_hdr *eth = eth_hdr(mbuf);
+    struct rte_arp_hdr *arp = rte_pktmbuf_mtod_offset(mbuf, struct rte_arp_hdr *, sizeof(struct rte_ether_hdr));
+
+    if (rte_be_to_cpu_16(arp->arp_hardware) != RTE_ARP_HRD_ETHER ||
+        rte_be_to_cpu_16(arp->arp_protocol) != RTE_ETHER_TYPE_IPV4 ||
+        arp->arp_hlen != 6 || arp->arp_plen != 4) {
+        return false;
+    }
+
+    uint32_t tip = arp->arp_data.arp_tip;
+    uint32_t sip = arp->arp_data.arp_sip;
+    uint32_t my_ip = ctx->ifaces[ingress_port].ip;
+    uint16_t op = rte_be_to_cpu_16(arp->arp_opcode);
+
+    if (op == RTE_ARP_OP_REQUEST) {
+        if (tip == my_ip) {
+            rte_ether_addr_copy(&eth->src_addr, &eth->dst_addr);
+            rte_ether_addr_copy((const struct rte_ether_addr *)ctx->ifaces[ingress_port].mac, &eth->src_addr);
+
+            arp->arp_opcode = rte_cpu_to_be_16(RTE_ARP_OP_REPLY);
+
+            rte_ether_addr_copy(&arp->arp_data.arp_sha, &arp->arp_data.arp_tha);
+            arp->arp_data.arp_tip = arp->arp_data.arp_sip;
+
+            rte_ether_addr_copy((const struct rte_ether_addr *)ctx->ifaces[ingress_port].mac, &arp->arp_data.arp_sha);
+            arp->arp_data.arp_sip = my_ip;
+
+            /* Learn the sender's MAC, IP. */
+            arp4_insert(&ctx->arp4, sip, arp->arp_data.arp_tha.addr_bytes);
+
+            uint64_t egress_tsc = rdtsc();
+            latency_record(&ctx->latency_hist[ingress_port], egress_tsc - ingress_tsc, ctx->cycles_per_ns);
+            enqueue_tx(ingress_port, &ctx->tx_buffers[ingress_port], mbuf);
+
+            return true;
+        }
+    } else if (op == RTE_ARP_OP_REPLY) {
+        if (tip == my_ip) {
+            /* Received a reply to my request. */
+            arp4_insert(&ctx->arp4, sip, arp->arp_data.arp_sha.addr_bytes);
+            rte_pktmbuf_free(mbuf);
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/* Handle IPv4 packets. */
+static bool handle_ipv4(rx_lcore_ctx_t *ctx, struct rte_mbuf *mbuf, uint16_t ingress_port, uint64_t ingress_tsc) {
+    if (!ctx->ifaces[ingress_port].configured) return false;
+
+    struct rte_ether_hdr *eth = eth_hdr(mbuf);
+    struct rte_ipv4_hdr *ipv4 = rte_pktmbuf_mtod_offset(mbuf, struct rte_ipv4_hdr *, sizeof(struct rte_ether_hdr));
+
+    uint32_t dst_ip = ipv4->dst_addr;
+
+    /* Local Delivery Check */
+    for (uint16_t i = 0; i < NUM_PORTS; i++) {
+        if (ctx->ifaces[i].configured && ctx->ifaces[i].ip == dst_ip) {
+            ctx->packets_local++;
+            rte_pktmbuf_free(mbuf); /* No local stack yet, so drop this. */
+            return true;
+        }
+    }
+
+    /* TTL Check */
+    if (ipv4->time_to_live <= 1) {
+        ctx->packets_ttl_exceeded++;
+        rte_pktmbuf_free(mbuf); // TODO: Send ICMP Time Exceeded.
+        return true;
+    }
+
+    /* Route Lookup */
+    uint32_t next_hop_ip;
+    uint16_t egress_port;
+    if (!lpm_lookup(&ctx->lpm, dst_ip, &next_hop_ip, &egress_port)) {
+        ctx->packets_no_route++;
+        rte_pktmbuf_free(mbuf); // TODO: Send ICMP Dest Unreachable.
+        return true;
+    }
+
+    if (next_hop_ip == 0) {
+        /* Directly connected network. */
+        next_hop_ip = dst_ip;
+    }
+
+    /* ARP Lookup */
+    uint8_t next_hop_mac[6];
+    if (!arp4_lookup(&ctx->arp4, next_hop_ip, next_hop_mac)) {
+        /* ARP Miss: Drop the IP packet and reuse the mbuf to send
+         * an ARP request out of egress_port. */
+        ctx->packets_arp_miss++;
+        send_arp_request(ctx, mbuf, egress_port, next_hop_ip);
+        return true;
+    }
+
+    /* IPv4 Header Rewrite */
+    ipv4->time_to_live--;
+    ipv4->hdr_checksum = 0;
+    ipv4->hdr_checksum = rte_ipv4_cksum(ipv4);
+
+    rte_ether_addr_copy((const struct rte_ether_addr *)ctx->ifaces[egress_port].mac, &eth->src_addr);
+    rte_ether_addr_copy((const struct rte_ether_addr *)next_hop_mac, &eth->dst_addr);
+
+    uint64_t egress_tsc = rdtsc();
+    latency_record(&ctx->latency_hist[ingress_port], egress_tsc - ingress_tsc, ctx->cycles_per_ns);
+    enqueue_tx(egress_port, &ctx->tx_buffers[egress_port], mbuf);
+
+    ctx->packets_routed++;
+    ctx->bytes_forwarded += mbuf->pkt_len;
+
+    return true;
+}
+
 /* Forward or flood one mbuf received on ingress_port. */
 static void forward_mbuf(rx_lcore_ctx_t *ctx, struct rte_mbuf *mbuf, uint16_t ingress_port,
                          uint64_t ingress_tsc) {
@@ -47,7 +202,40 @@ static void forward_mbuf(rx_lcore_ctx_t *ctx, struct rte_mbuf *mbuf, uint16_t in
         mac_table_insert(&ctx->mac_table, src_mac, ingress_port, ingress_tsc);
     }
 
-    /* Forwarding decision. */
+    /* L3 Classification. */
+    bool is_broadcast = mac_is_broadcast(dst_mac);
+    bool for_us = is_broadcast;
+
+    if (!for_us && ctx->ifaces[ingress_port].configured) {
+        if (memcmp(dst_mac, ctx->ifaces[ingress_port].mac, 6) == 0) {
+            for_us = true;
+        }
+    }
+
+    if (for_us) {
+        uint16_t eth_type = rte_be_to_cpu_16(hdr->ether_type);
+        bool consumed = false;
+
+        if (eth_type == RTE_ETHER_TYPE_ARP) {
+            consumed = handle_arp(ctx, mbuf, ingress_port, ingress_tsc);
+        } else if (eth_type == RTE_ETHER_TYPE_IPV4 && !is_broadcast) {
+            consumed = handle_ipv4(ctx, mbuf, ingress_port, ingress_tsc);
+        }
+
+        if (consumed) return;
+
+        /* Unicast meant for us, but unknown Ethertype. */
+        if (!is_broadcast && memcmp(dst_mac, ctx->ifaces[ingress_port].mac, 6) == 0) {
+            rte_pktmbuf_free(mbuf);
+            ctx->packets_dropped++;
+            return;
+        }
+
+        /* If it's broadcast (DHCP, LLDP...) and not consumed, 
+         * fall through to L2 flooding. */
+    }
+
+    /* Forwarding decision (L2 Fallback). */
     bool should_flood = mac_is_broadcast(dst_mac) || !mac_is_unicast(dst_mac);
 
     uint16_t egress_port = 0;
@@ -79,7 +267,7 @@ static void forward_mbuf(rx_lcore_ctx_t *ctx, struct rte_mbuf *mbuf, uint16_t in
             if (p != ingress_port) egress_ports[n_egress++] = p;
         }
 
-        /* Allocate colones for the egress port. */
+        /* Allocate clones for the egress port. */
         bool alloc_ok = true;
         copies[0] = mbuf; /* First egress gets the original pointer. */
 


### PR DESCRIPTION
Implements the IPv4 forwarding with TTL decrement, checksum
recalculation, Longest Prefix Match (LPM) route lookups and Ethernet
header MAC rewriting.

Handles ARP Requests for the router's IP, modifies the rte_mbuf in-place
to reply it.

When there's an ARP Miss, then UPE drops the IP payload, overwrites the
mbuf with an outgoing ARP Request to discoverd the target.

forward_mbuf checks if the packets are addressed to the router's MAC (or
broadcasts).. these are handled by the L3 engine. Other subnet local
packets fall through the L2 switching (learning/forwarding/flooding).