### PR TITLE
feat(router): Implement ICMP Echo responder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
           touch router/bench/rte_mbuf.h
           touch router/bench/rte_ip.h
           touch router/bench/rte_arp.h
+          touch router/bench/rte_icmp.h
           touch router/bench/rte_byteorder.h
 
           cat << 'EOF' > ./mock_pkgconfig/libdpdk.pc

--- a/router/bench/mock_dpdk.h
+++ b/router/bench/mock_dpdk.h
@@ -17,6 +17,7 @@
 #define _RTE_MBUF_H_
 #define _RTE_IP_H_
 #define _RTE_ARP_H_
+#define _RTE_ICMP_H_ 
 #define _RTE_BYTEORDER_H_
 #define _RTE_BYTEORDER_X86_H_
 #define _RTE_BYTEORDER_ARM_H_
@@ -168,12 +169,17 @@ static inline uint16_t rte_eth_rx_burst(uint16_t port_id, uint16_t queue_id, str
 
 /* L3 DPDK MOCKS */
 #define rte_pktmbuf_mtod_offset(m, t, o) ((t)((char *)(m)->buf_addr + (o)))
-#define rte_be_to_cpu_16(x) (x)
-#define rte_be_to_cpu_32(x) (x)
-#define rte_cpu_to_be_16(x) (x)
-#define rte_cpu_to_be_32(x) (x)
+#define rte_be_to_cpu_16(x) __builtin_bswap16(x)
+#define rte_be_to_cpu_32(x) __builtin_bswap32(x)
+#define rte_cpu_to_be_16(x) __builtin_bswap16(x)
+#define rte_cpu_to_be_32(x) __builtin_bswap32(x)
 
 #define RTE_ETHER_TYPE_IPV4 0x0800
+#define RTE_IPV4(a, b, c, d) ((uint32_t)(((a) & 0xff) << 24) | \
+                              (((b) & 0xff) << 16) | \
+                              (((c) & 0xff) << 8)  | \
+                              ((d) & 0xff))
+#define IPPROTO_ICMP 1
 #define RTE_ETHER_TYPE_ARP  0x0806
 #define RTE_ARP_HRD_ETHER 1
 #define RTE_ARP_OP_REQUEST 1
@@ -215,5 +221,20 @@ struct rte_arp_hdr {
     uint16_t arp_opcode;
     struct rte_arp_ipv4 arp_data;
 } __attribute__((__packed__));
+
+#define RTE_IP_ICMP_ECHO_REPLY   0
+#define RTE_IP_ICMP_ECHO_REQUEST 8
+
+struct rte_icmp_hdr {
+    uint8_t  icmp_type;
+    uint8_t  icmp_code;
+    uint16_t icmp_cksum;
+    uint16_t icmp_ident;
+    uint16_t icmp_seq_nb;
+} __attribute__((__packed__));
+
+static inline uint16_t rte_raw_cksum(const void *buf, size_t len) {
+    (void)buf; (void)len; return 0;
+}
 
 #endif // MOCK_DPDK_H

--- a/router/bench/test_forwarding.c
+++ b/router/bench/test_forwarding.c
@@ -29,6 +29,8 @@ static int g_tests_failed = 0;
 static const uint8_t MAC_HOST_A[6] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x0A};
 static const uint8_t MAC_HOST_B[6] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x0B};
 static const uint8_t MAC_BROADCAST[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+static const uint8_t MAC_ROUTER_0[6] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x00};
+#define IP_ROUTER_0 rte_cpu_to_be_32(RTE_IPV4(10, 128, 0, 1))
 
 static void setup_ctx(rx_lcore_ctx_t *ctx) {
     memset(ctx, 0, sizeof(rx_lcore_ctx_t));
@@ -168,6 +170,55 @@ static void test_system_malformed_packet_drop() {
     ASSERT(mock_mbuf_freed == freed_before + 1, "Malformed frame buffer must be released");
 }
 
+static void test_icmp_echo_reply() {
+    rx_lcore_ctx_t ctx;
+    setup_ctx(&ctx);
+
+    /* Configure Router Port 0 */
+    ctx.ifaces[0].configured = true;
+    ctx.ifaces[0].ip = IP_ROUTER_0;
+    memcpy(ctx.ifaces[0].mac, MAC_ROUTER_0, 6);
+
+    /* Build ICMP Echo Request packet from Host A to Router's Port 0 IP */
+    struct rte_mbuf *pkt = mock_build_packet(0, MAC_HOST_A, MAC_ROUTER_0, RTE_ETHER_TYPE_IPV4);
+    pkt->data_len = sizeof(struct rte_ether_hdr) + sizeof(struct rte_ipv4_hdr) + sizeof(struct rte_icmp_hdr);
+    pkt->pkt_len = pkt->data_len;
+
+    struct rte_ipv4_hdr *ipv4 = (struct rte_ipv4_hdr *)((uint8_t *)pkt->buf_addr + sizeof(struct rte_ether_hdr));
+    ipv4->version_ihl = 0x45;
+    ipv4->time_to_live = 64;
+    ipv4->next_proto_id = IPPROTO_ICMP;
+    ipv4->src_addr = rte_cpu_to_be_32(RTE_IPV4(10, 128, 0, 50));
+    ipv4->dst_addr = IP_ROUTER_0;
+
+    struct rte_icmp_hdr *icmp = (struct rte_icmp_hdr *)((uint8_t *)ipv4 + sizeof(struct rte_ipv4_hdr));
+    icmp->icmp_type = RTE_IP_ICMP_ECHO_REQUEST;
+    icmp->icmp_code = 0;
+    icmp->icmp_cksum = 0xFFFF;
+
+    uint32_t freed_before = mock_mbuf_freed;
+
+    forward_mbuf(&ctx, pkt, 0, rdtsc());
+
+    ASSERT(ctx.packets_local == 1, "Packet should be matched as local traffic");
+    ASSERT(ctx.tx_buffers[0].count == 1, "ICMP Echo Reply should be in TX queue");
+    ASSERT(mock_mbuf_freed == freed_before, "Mbuf should be reused, not freed");
+
+    if (ctx.tx_buffers[0].count > 0) {
+        struct rte_mbuf *reply_pkt = ctx.tx_buffers[0].mbufs[0];
+        struct rte_ether_hdr *reply_eth = (struct rte_ether_hdr *)reply_pkt->buf_addr;
+        struct rte_ipv4_hdr *reply_ipv4 = (struct rte_ipv4_hdr *)((uint8_t *)reply_pkt->buf_addr + sizeof(struct rte_ether_hdr));
+        struct rte_icmp_hdr *reply_icmp = (struct rte_icmp_hdr *)((uint8_t *)reply_ipv4 + sizeof(struct rte_ipv4_hdr));
+
+        ASSERT(memcmp(reply_eth->dst_addr.addr_bytes, MAC_HOST_A, 6) == 0, "Reply DST MAC should be Host A");
+        ASSERT(memcmp(reply_eth->src_addr.addr_bytes, MAC_ROUTER_0, 6) == 0, "Reply SRC MAC should be Router Port 0");
+
+        ASSERT(reply_ipv4->dst_addr == rte_cpu_to_be_32(RTE_IPV4(10, 128, 0, 50)), "Reply DST IP should be Host A");
+        ASSERT(reply_ipv4->src_addr == IP_ROUTER_0, "Reply SRC IP should be Router Port 0");
+        ASSERT(reply_icmp->icmp_type == RTE_IP_ICMP_ECHO_REPLY, "ICMP Type should be Echo Reply");
+    }
+}
+
 int main() {
     printf("Running Forwarding Tests...\n");
     printf("--------------------------------------------------\n");
@@ -178,6 +229,7 @@ int main() {
     test_hairpin_drop();
     test_system_mac_migration();
     test_system_malformed_packet_drop();
+    test_icmp_echo_reply();
 
     printf("\nResults: %d Passed, %d Failed\n", g_tests_passed, g_tests_failed);
 

--- a/router/src/rx_lcore.c
+++ b/router/src/rx_lcore.c
@@ -4,6 +4,7 @@
 #include <rte_mbuf.h>
 #include <rte_ip.h>
 #include <rte_arp.h>
+#include <rte_icmp.h>
 #include <rte_byteorder.h>
 #include <string.h>
 
@@ -123,7 +124,44 @@ static bool handle_arp(rx_lcore_ctx_t *ctx, struct rte_mbuf *mbuf, uint16_t ingr
     return false;
 }
 
-/* Handle IPv4 packets. */
+/* Handle ICMP Echo Requests to the router. */
+static bool handle_icmp_echo(rx_lcore_ctx_t *ctx, struct rte_mbuf *mbuf, uint16_t ingress_port, uint64_t ingress_tsc) {
+    struct rte_ether_hdr *eth = eth_hdr(mbuf);
+    struct rte_ipv4_hdr *ipv4 = rte_pktmbuf_mtod_offset(mbuf, struct rte_ipv4_hdr *, sizeof(struct rte_ether_hdr));
+
+    uint16_t ihl_bytes = (ipv4->version_ihl & 0x0f) * 4;
+    struct rte_icmp_hdr *icmp = (struct rte_icmp_hdr *)((uint8_t *)ipv4 + ihl_bytes);
+
+    if (icmp->icmp_type == RTE_IP_ICMP_ECHO_REQUEST) {
+        /* Swap MACs */
+        rte_ether_addr_copy(&eth->src_addr, &eth->dst_addr);
+        rte_ether_addr_copy((const struct rte_ether_addr *)ctx->ifaces[ingress_port].mac, &eth->src_addr);
+
+        /* Swap IPs */
+        uint32_t tmp_ip = ipv4->src_addr;
+        ipv4->src_addr = ipv4->dst_addr;
+        ipv4->dst_addr = tmp_ip;
+
+        /* Update to ICMP Reply */
+        icmp->icmp_type = RTE_IP_ICMP_ECHO_REPLY;
+
+        /* Incrementally update ICMP checksum (Type changed from 8 to 0) */
+        uint32_t cksum = ~icmp->icmp_cksum & 0xFFFF;
+        cksum += rte_cpu_to_be_16(0x0800);
+        cksum = (cksum & 0xFFFF) + (cksum >> 16);
+        icmp->icmp_cksum = ~cksum & 0xFFFF;
+
+        uint64_t egress_tsc = rdtsc();
+        latency_record(&ctx->latency_hist[ingress_port], egress_tsc - ingress_tsc, ctx->cycles_per_ns);
+        enqueue_tx(ingress_port, &ctx->tx_buffers[ingress_port], mbuf);
+
+        return true;
+    }
+
+    return false;
+}
+
+/* Handle IPv4 packets */
 static bool handle_ipv4(rx_lcore_ctx_t *ctx, struct rte_mbuf *mbuf, uint16_t ingress_port, uint64_t ingress_tsc) {
     if (!ctx->ifaces[ingress_port].configured) return false;
 
@@ -136,7 +174,15 @@ static bool handle_ipv4(rx_lcore_ctx_t *ctx, struct rte_mbuf *mbuf, uint16_t ing
     for (uint16_t i = 0; i < NUM_PORTS; i++) {
         if (ctx->ifaces[i].configured && ctx->ifaces[i].ip == dst_ip) {
             ctx->packets_local++;
-            rte_pktmbuf_free(mbuf); /* No local stack yet, so drop this. */
+           
+            /* Responding to ICMP */
+            if (ipv4->next_proto_id == IPPROTO_ICMP) {
+                if (handle_icmp_echo(ctx, mbuf, ingress_port, ingress_tsc)) {
+                    return true;
+                }
+            }
+
+            rte_pktmbuf_free(mbuf); /* Drop other traffic for local stack */
             return true;
         }
     }


### PR DESCRIPTION
Extend rx_lcore with ICMP Echo Responder functionality to handle ICMP Type 8 requests destined for the local router interfaces. Flip them to Type 0 replies and place them back to the ingress port TX buffer.