### PR TITLE
feat(router): implement IPC control plane

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,7 @@ add_executable(upe-router
   router/src/lpm.c
   router/src/arp4.c
   router/src/rx_lcore.c
+  router/src/ctrl_plane.c
   src/latency.c
   src/log.c
 )

--- a/router/bench/bench_mac_table.c
+++ b/router/bench/bench_mac_table.c
@@ -71,7 +71,7 @@ static void test_insert_lookup_roundtrip(void) {
          * seed*2 gives: 0, 2, 4 ... 254, always unique unicast. **/
         make_unicast_mac(mac, (uint8_t)(seed * 2));
 
-        uint16_t insert_port = (uint16_t)(seed % NUM_PORTS);
+        uint16_t insert_port = (uint16_t)(seed % MAX_PORTS);
         uint64_t tsc = (uint64_t)(seed + 1) * 1000;
 
         bool ok = mac_table_insert(&table, mac, insert_port, tsc);
@@ -249,7 +249,7 @@ static void test_table_saturation_and_probe_limit(void) {
 
     /* Fill the table up to the max allowed probe depth */
     for (int i = 0; i < MAC_TABLE_MAX_PROBE; i++) {
-        bool ok = mac_table_insert(&table, macs[i], (uint16_t)(i % NUM_PORTS), tsc);
+        bool ok = mac_table_insert(&table, macs[i], (uint16_t)(i % MAX_PORTS), tsc);
         ASSERT(ok, "P6: Insert within table bounds should succeed");
     }
 
@@ -266,7 +266,7 @@ static void test_table_saturation_and_probe_limit(void) {
         uint16_t out_port = 0xFF;
         bool found = mac_table_lookup(&table, macs[i], tsc, &out_port);
         ASSERT(found, "P6: Original entries must remain after overflow error");
-        ASSERT(out_port == (uint16_t)(i % NUM_PORTS),
+        ASSERT(out_port == (uint16_t)(i % MAX_PORTS),
                "P6: Original entry port mapping must remain");
     }
 }

--- a/router/bench/mock_dpdk.h
+++ b/router/bench/mock_dpdk.h
@@ -29,7 +29,7 @@
 
 #define MAC_ADDR_LEN 6
 #define RTE_PKTMBUF_HEADROOM 128
-#define NUM_PORTS 2
+#define MAX_PORTS 2
 #define BURST_SIZE 32
 #define MOCK_MBUF_SIZE 2048
 

--- a/router/bench/test_forwarding.c
+++ b/router/bench/test_forwarding.c
@@ -36,6 +36,9 @@ static void setup_ctx(rx_lcore_ctx_t *ctx) {
     memset(ctx, 0, sizeof(rx_lcore_ctx_t));
     mac_table_init(&ctx->mac_table, 30, 2.0);
     ctx->cycles_per_ns = 2.0;
+
+    /* Plug in Port 0 and Port 1 */
+    ctx->active_ports_mask = (1ULL << 0) | (1ULL << 1);
 }
 
 static void test_mac_learning_and_flooding() {

--- a/router/include/ctrl_plane.h
+++ b/router/include/ctrl_plane.h
@@ -1,0 +1,10 @@
+#ifndef CTRL_PLANE_H
+#define CTRL_PLANE_H
+
+#include "router.h"
+
+#define UPE_IPC_SOCKET "/var/run/upe/router.sock"
+
+int ctrl_plane_start(rx_lcore_ctx_t *ctx, struct rte_mempool *pool);
+
+#endif

--- a/router/include/router.h
+++ b/router/include/router.h
@@ -9,7 +9,7 @@
 #include "arp4.h"
 #include "latency.h"
 
-#define NUM_PORTS 2
+#define MAX_PORTS 64
 
 #define BURST_SIZE 32 /* RX/TX burst size */
 
@@ -50,10 +50,12 @@ typedef struct {
     mac_table_t mac_table;
     lpm_table_t lpm;
     arp4_table_t arp4;
-    router_iface_t ifaces[NUM_PORTS];
+    router_iface_t ifaces[MAX_PORTS];
 
-    tx_buffer_t tx_buffers[NUM_PORTS];
-    latency_histogram_t latency_hist[NUM_PORTS];
+    tx_buffer_t tx_buffers[MAX_PORTS];
+    latency_histogram_t latency_hist[MAX_PORTS];
+
+    uint64_t active_ports_mask;
 
     uint64_t packets_forwarded;
     uint64_t bytes_forwarded;
@@ -74,7 +76,7 @@ typedef struct {
 typedef struct {
     router_config_t config;
     struct rte_mempool *mbuf_pool;
-    uint16_t port_ids[NUM_PORTS];
+    uint16_t port_ids[MAX_PORTS];
     rx_lcore_ctx_t rx_ctx;
     uint64_t start_tsc;
     uint64_t end_tsc;
@@ -82,5 +84,8 @@ typedef struct {
 
 int rx_lcore_main(void *arg);
 void signal_handler(int signum);
+
+int port_init(uint16_t port_id, struct rte_mempool *mbuf_pool,
+              uint32_t link_wait_sec);
 
 #endif /* ROUTER_H */

--- a/router/src/ctrl_plane.c
+++ b/router/src/ctrl_plane.c
@@ -1,0 +1,150 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <sys/stat.h>
+#include <rte_log.h>
+#include <rte_eal.h>
+#include <rte_ethdev.h>
+
+#include "ctrl_plane.h"
+
+static struct rte_mempool *g_pool;
+
+#define RTE_LOGTYPE_CTRL RTE_LOGTYPE_USER1
+
+static rx_lcore_ctx_t *g_ctx;
+static int server_fd = -1;
+
+/* attach_vhost_port: Create a new virtual network card. */
+static int attach_vhost_port(const char *port_name, const char *sock_path) {
+    char devargs[256];
+
+    /* 'client=1' is required so the router connects to the Pod/QEMU and not 
+     * the opposite way. */
+    snprintf(devargs, sizeof(devargs), "iface=%s,client=1", sock_path);
+
+    uint16_t port_id;
+
+    int ret = rte_eal_hotplug_add("vdev", port_name, devargs);
+    if (ret < 0) {
+        RTE_LOG(ERR, CTRL, "Failed to hotplug %s: %s\n", port_name, strerror(-ret));
+        return ret;
+    }
+
+    ret = rte_eth_dev_get_port_by_name(port_name, &port_id);
+    if (ret < 0) return ret;
+
+    ret = port_init(port_id, g_pool, 0);
+    if (ret < 0) {
+        RTE_LOG(ERR, CTRL, "Failed to initialize hotplugged port %d\n", port_id);
+        return ret;
+    }
+    
+    return port_id;
+}
+
+/* handle_client: Read the command from the CNI script over the UNIX socket. */
+static void handle_client(int client_fd) {
+    char buf[512];
+
+    ssize_t n = read(client_fd, buf, sizeof(buf) - 1);
+    if (n <= 0) {
+        close(client_fd);
+        return;
+    }
+    buf[n] = '\0';
+
+    /* Expectation is that the command formatted as: 
+     * "ADD_VHOST examplepod 10.128.0.50 00:11:22:33:44:55" */
+    char cmd[32], pod_id[64], ip_str[32], mac_str[32];
+
+    if (sscanf(buf, "%31s %63s %31s %31s", cmd, pod_id, ip_str, mac_str) == 4) {
+
+        if (strcmp(cmd, "ADD_VHOST") == 0) {
+
+            char port_name[64];
+            snprintf(port_name, sizeof(port_name), "net_vhost_%s", pod_id);
+
+            char sock_path[128];
+            snprintf(sock_path, sizeof(sock_path), "/var/run/upe/vhost-%s.sock", pod_id);
+
+            RTE_LOG(INFO, CTRL, "IPC received: attaching %s at %s\n", port_name, sock_path);
+
+            int port_id = attach_vhost_port(port_name, sock_path);
+            if (port_id >= 0 && port_id < MAX_PORTS) {
+                /* TODO: Dynamic Route Injection */
+
+                /* To avoid lock contention in the rx_lcore polling loop, notify it about the new port
+                * using atomic bitmask. */
+                __atomic_or_fetch(&g_ctx->active_ports_mask, (1ULL << port_id), __ATOMIC_RELEASE);
+
+                /* Response to the CNI. */
+                const char *resp = "OK\n";
+                write(client_fd, resp, strlen(resp));
+
+            } else {
+                const char *resp = "ERR\n";
+                write(client_fd, resp, strlen(resp));
+            }
+        }
+    }
+    close(client_fd);
+}
+
+/* ctrl_plane_thread: Listen for connections. */
+static void *ctrl_plane_thread(void *arg) {
+    (void)arg;
+
+    server_fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (server_fd < 0) return NULL;
+
+    struct sockaddr_un addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    strncpy(addr.sun_path, UPE_IPC_SOCKET, sizeof(addr.sun_path) - 1);
+
+    /* Remove any leftover socket file. */
+    unlink(UPE_IPC_SOCKET);
+
+    if (bind(server_fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+        close(server_fd);
+        return NULL;
+    }
+
+    chmod(UPE_IPC_SOCKET, 0600);
+
+    /* Queue up to 10 incoming CNI connections at once. */
+    listen(server_fd, 10);
+
+    RTE_LOG(INFO, CTRL, "Control Plane listening on %s\n", UPE_IPC_SOCKET);
+
+    while (g_ctx && !g_ctx->stop) {
+        int client_fd = accept(server_fd, NULL, NULL);
+        if (client_fd >= 0) {
+            handle_client(client_fd);
+        }
+    }
+
+    close(server_fd);
+    unlink(UPE_IPC_SOCKET);
+    return NULL;
+}
+
+int ctrl_plane_start(rx_lcore_ctx_t *ctx, struct rte_mempool *pool) {
+    g_ctx = ctx;
+    g_pool = pool;
+
+    system("mkdir -p /var/run/upe");
+
+    pthread_t thread;
+    if (pthread_create(&thread, NULL, ctrl_plane_thread, NULL) != 0) {
+        return -1;
+    }
+
+    pthread_detach(thread);
+    return 0;
+}

--- a/router/src/main.c
+++ b/router/src/main.c
@@ -21,6 +21,8 @@
 
 #include "router.h"
 #include "mac_table.h"
+#include "ctrl_plane.h"
+
 
 
 static router_state_t g_router;
@@ -106,7 +108,7 @@ static int parse_app_args(int argc, char **argv, router_config_t *config) {
     return 0;
 }
 
-static int port_init(uint16_t port_id, struct rte_mempool *mbuf_pool,
+int port_init(uint16_t port_id, struct rte_mempool *mbuf_pool,
                      uint32_t link_wait_sec) {
     struct rte_eth_conf port_conf = {0};
     const uint16_t rx_rings = 1;
@@ -209,7 +211,7 @@ static int port_init(uint16_t port_id, struct rte_mempool *mbuf_pool,
 
 static void print_stats(const rx_lcore_ctx_t *ctx) {
     /* Print latency histogram for each port */
-    for (uint16_t port = 0; port < NUM_PORTS; port++) {
+    for (uint16_t port = 0; port < MAX_PORTS; port++) {
         const latency_histogram_t *hist = &ctx->latency_hist[port];
 
         if (hist->total_count == 0) {
@@ -318,19 +320,19 @@ int main(int argc, char **argv) {
         log_msg(LOG_INFO, "Found %u physical ports", nb_ports);
     }
 
-    if (nb_ports != NUM_PORTS) {
-        log_msg(LOG_ERROR, "Expected %u ports, found %u", NUM_PORTS, nb_ports);
+    if (nb_ports == 0) {
+        log_msg(LOG_ERROR, "No ports found. Cannot start router.");
         rte_eal_cleanup();
         return EXIT_FAILURE;
     }
 
     uint16_t port_id;
     RTE_ETH_FOREACH_DEV(port_id) {
-        if (port_id >= NUM_PORTS) {
-            break;
-        }
+        if (port_id >= MAX_PORTS) break;
 
         g_router.port_ids[port_id] = port_id;
+
+        g_router.rx_ctx.active_ports_mask |= (1ULL << port_id);
 
         ret = port_init(port_id, g_router.mbuf_pool,
                         g_router.config.link_wait_sec);
@@ -348,7 +350,7 @@ int main(int argc, char **argv) {
                    g_router.config.aging_timeout_sec,
                    cycles_per_ns);
     
-    for (uint16_t i = 0; i < NUM_PORTS; i++) {
+    for (uint16_t i = 0; i < MAX_PORTS; i++) {
         latency_histogram_init(&g_router.rx_ctx.latency_hist[i]);
         g_router.rx_ctx.tx_buffers[i].count = 0;
     }
@@ -359,6 +361,13 @@ int main(int argc, char **argv) {
 
     signal(SIGINT, signal_handler);
     signal(SIGTERM, signal_handler);
+
+    /* Start the IPC UNIX Socket Server */
+    if (ctrl_plane_start(&g_router.rx_ctx, g_router.mbuf_pool) != 0) {
+        log_msg(LOG_ERROR, "Failed to start Control Plane IPC server");
+        rte_eal_cleanup();
+        return EXIT_FAILURE;
+    }
 
     /* Get the first worker lcore */
     lcore_id = rte_get_next_lcore(-1, 1, 0);
@@ -426,7 +435,7 @@ int main(int argc, char **argv) {
                         (duration_sec * 1000000000.0);
         
         uint64_t p50 = 0, p99 = 0, p999 = 0, min_ns = 0, max_ns = 0;
-        for (uint16_t port = 0; port < NUM_PORTS; port++) {
+        for (uint16_t port = 0; port < MAX_PORTS; port++) {
             const latency_histogram_t * hist =
                 &g_router.rx_ctx.latency_hist[port];
             if (hist->total_count > 0) {
@@ -467,7 +476,7 @@ int main(int argc, char **argv) {
 
     /* Stop and close ports */
     RTE_ETH_FOREACH_DEV(port_id) {
-        if (port_id >= NUM_PORTS) {
+        if (port_id >= MAX_PORTS) {
             break;
         }
 

--- a/router/src/rx_lcore.c
+++ b/router/src/rx_lcore.c
@@ -171,7 +171,7 @@ static bool handle_ipv4(rx_lcore_ctx_t *ctx, struct rte_mbuf *mbuf, uint16_t ing
     uint32_t dst_ip = ipv4->dst_addr;
 
     /* Local Delivery Check */
-    for (uint16_t i = 0; i < NUM_PORTS; i++) {
+    for (uint16_t i = 0; i < MAX_PORTS; i++) {
         if (ctx->ifaces[i].configured && ctx->ifaces[i].ip == dst_ip) {
             ctx->packets_local++;
            
@@ -305,12 +305,18 @@ static void forward_mbuf(rx_lcore_ctx_t *ctx, struct rte_mbuf *mbuf, uint16_t in
             ctx->bytes_forwarded += mbuf->pkt_len;
         }
     } else { /* Flood to all ports except ingress. */
-        struct rte_mbuf *copies[NUM_PORTS];
-        uint16_t egress_ports[NUM_PORTS];
+        struct rte_mbuf *copies[MAX_PORTS];
+        uint16_t egress_ports[MAX_PORTS];
         uint16_t n_egress = 0;
 
-        for (uint16_t p = 0; p < NUM_PORTS; p++) {
-            if (p != ingress_port) egress_ports[n_egress++] = p;
+        uint64_t active_ports = __atomic_load_n(&ctx->active_ports_mask,
+                                                __ATOMIC_ACQUIRE);
+
+        for (uint16_t p = 0; p < MAX_PORTS; p++) {
+            /* Port's bit should be 1 and not ingress port. */
+            if ((active_ports & (1ULL << p)) && (p != ingress_port)) {
+                egress_ports[n_egress++] = p;
+            }
         }
 
         /* Allocate clones for the egress port. */
@@ -353,28 +359,40 @@ int rx_lcore_main(void *arg) {
     struct rte_mbuf *rx_mbufs[BURST_SIZE];
 
     while (!ctx->stop) {
-        for (uint16_t port = 0; port < NUM_PORTS; port++) {
-            uint16_t nb_rx = rte_eth_rx_burst(port, 0, rx_mbufs, BURST_SIZE);
+        uint64_t active_ports = __atomic_load_n(&ctx->active_ports_mask,
+                                                __ATOMIC_ACQUIRE);
+
+        for (uint16_t p = 0; p < MAX_PORTS; p++) {
+            if (!(active_ports & (1ULL << p))) continue;
+            
+            uint16_t nb_rx = rte_eth_rx_burst(p, 0, rx_mbufs, BURST_SIZE);
 
             if (nb_rx > 0) {
                 uint64_t ingress_tsc = rdtsc();
 
                 for (uint16_t i = 0; i < nb_rx; i++) {
-                    forward_mbuf(ctx, rx_mbufs[i], port, ingress_tsc);
+                    forward_mbuf(ctx, rx_mbufs[i], p, ingress_tsc);
                 }
             }
         }
 
-        /* Flush happens at every pass */
-        for (uint16_t p = 0; p < NUM_PORTS; p++) {
-            flush_tx_buffer(p, &ctx->tx_buffers[p]);
+        /* Flush happens at every pass. */
+        for (uint16_t p = 0; p < MAX_PORTS; p++) {
+            if (active_ports & (1ULL << p)) {
+                flush_tx_buffer(p, &ctx->tx_buffers[p]);
+            }
         }
     }
 
     log_msg(LOG_INFO, "RX lcore %u stopping, will flush TX buffers...", rte_lcore_id());
 
-    for (uint16_t p = 0; p < NUM_PORTS; p++) {
-        flush_tx_buffer(p, &ctx->tx_buffers[p]);
+    /* Final flush before shutdown. */
+    uint64_t active_ports = __atomic_load_n(&ctx->active_ports_mask,
+                                            __ATOMIC_ACQUIRE);
+    for (uint16_t p = 0; p < MAX_PORTS; p++) {
+        if (active_ports & (1ULL << p)) {
+            flush_tx_buffer(p, &ctx->tx_buffers[p]);
+        }
     }
 
     log_msg(LOG_INFO, "RX lcore %u stopped", rte_lcore_id());


### PR DESCRIPTION
First steps for the CNI prerequisites. This commit implements a ontrol plane that listens on a UNIX domain socket to dynamically hotplug vhost-user client ports at runtime. Port number is increased to 64 and port mask is used to sync the port state in the rx_lcore polling loop.