### PR TITLE
feat(cni): implement initial CNI plugin

### DIFF
--- a/router/cni/upe-rtr-cni
+++ b/router/cni/upe-rtr-cni
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# The container runtime passes the below environment variables.
+NETNS=$CNI_NETNS
+CONTAINER_ID=$CNI_CONTAINERID
+IFNAME=$CNI_IFNAME
+COMMAND=$CNI_COMMAND
+
+NETNS_NAME=$(basename $NETNS)
+
+IPC_SOCKET="/var/run/upe/router.sock"
+POD_ID_SHORT=$(echo $CONTAINER_ID | cut -c 1-8)
+TAP_NAME="tap_${POD_ID_SHORT}"
+
+# Read the JSON config from the container runtime.
+CONFIG=$(cat)
+
+# Delegate IPAM to host-local binary.
+IPAM_RESULT=$(echo "$CONFIG" | /var/lib/rancher/k3s/data/cni/host-local)
+
+if [ $? -ne 0 ]; then
+    echo "IPAM failed: $IPAM_RESULT" >&2
+    exit 1
+fi
+
+if [ "$COMMAND" = "ADD" ]; then
+    # Extract the allocated IP address from the IPAM JSON response.
+    POD_IP_CIDR=$(echo "$IPAM_RESULT" | jq -r '.ips[0].address')
+    POD_IP=$(echo "$POD_IP_CIDR" | cut -d'/' -f1)
+
+    # Generate random MAC address.
+    POD_MAC=$(printf '02:%02x:%02x:%02x:%02x:%02x' $((RANDOM%256)) $((RANDOM%256)) $((RANDOM%256)) $((RANDOM%256)) $((RANDOM%256)))
+
+    echo "ADD_TAP ${POD_ID_SHORT} ${POD_IP} ${POD_MAC}" | nc -U $IPC_SOCKET > /dev/null
+
+    sleep 0.5
+
+    # Move the DPDK TAP interface into the container's network NS.
+    ip link set $TAP_NAME netns $NETNS
+
+    # Configure the interface inside the container.
+    ip -n $NETNS_NAME link set $TAP_NAME name $IFNAME
+    ip -n $NETNS_NAME addr add ${POD_IP}/32 dev $IFNAME
+    ip -n $NETNS_NAME link set $IFNAME address $POD_MAC
+    ip -n $NETNS_NAME link set $IFNAME up
+    ip -n $NETNS_NAME route add default dev $IFNAME
+
+    cat <<EOF # Output the standard CNI JSON Response back to the container runtime.
+{
+    "cniVersion": "0.3.1",
+    "interfaces": [
+        {
+            "name": "$IFNAME",
+            "mac": "$POD_MAC"
+        }
+    ],
+    "ips": [
+        {
+            "version": "4",
+            "address": "${POD_IP}/32",
+            "interface": 0
+        }
+    ]
+}
+EOF
+
+elif [ "$COMMAND" = "DEL" ]; then
+    echo "DEL_TAP ${POD_ID_SHORT}" | nc -U $IPC_SOCKET > /dev/null
+fi

--- a/router/include/lpm.h
+++ b/router/include/lpm.h
@@ -23,5 +23,6 @@ typedef struct {
 void lpm_init(lpm_table_t *table);
 bool lpm_insert(lpm_table_t *table, uint32_t prefix, uint8_t prefix_len, uint32_t next_hop_ip, uint16_t egress_port);
 bool lpm_lookup(const lpm_table_t *table, uint32_t dest_ip, uint32_t *out_next_hop, uint16_t *out_port);
+bool lpm_delete(lpm_table_t *table, uint32_t prefix, uint8_t prefix_len);
 
 #endif /* LPM_H */

--- a/router/src/ctrl_plane.c
+++ b/router/src/ctrl_plane.c
@@ -20,14 +20,7 @@ static struct rte_mempool *g_pool;
 static rx_lcore_ctx_t *g_ctx;
 static int server_fd = -1;
 
-/* attach_vhost_port: Create a new virtual network card. */
-static int attach_vhost_port(const char *port_name, const char *sock_path) {
-    char devargs[256];
-
-    /* 'client=1' is required so the router connects to the Pod/QEMU and not 
-     * the opposite way. */
-    snprintf(devargs, sizeof(devargs), "iface=%s,client=1", sock_path);
-
+static int attach_tap_port(const char *port_name, const char *devargs) {
     uint16_t port_id;
 
     int ret = rte_eal_hotplug_add("vdev", port_name, devargs);
@@ -41,10 +34,10 @@ static int attach_vhost_port(const char *port_name, const char *sock_path) {
 
     ret = port_init(port_id, g_pool, 0);
     if (ret < 0) {
-        RTE_LOG(ERR, CTRL, "Failed to initialize hotplugged port %d\n", port_id);
+        RTE_LOG(ERR, CTRL, "Failed to init hotplugged port %d\n", port_id);
         return ret;
     }
-    
+
     return port_id;
 }
 
@@ -62,20 +55,21 @@ static void handle_client(int client_fd) {
     /* Expectation is that the command formatted as: 
      * "ADD_VHOST examplepod 10.128.0.50 00:11:22:33:44:55" */
     char cmd[32], pod_id[64], ip_str[32], mac_str[32];
+    int parsed = sscanf(buf, "%31s %63s %31s %31s", cmd, pod_id, ip_str, mac_str);
 
-    if (sscanf(buf, "%31s %63s %31s %31s", cmd, pod_id, ip_str, mac_str) == 4) {
+    if (parsed >= 2) {
 
-        if (strcmp(cmd, "ADD_VHOST") == 0) {
+        if (strcmp(cmd, "ADD_TAP") == 0 && parsed == 4) {
 
             char port_name[64];
-            snprintf(port_name, sizeof(port_name), "net_vhost_%s", pod_id);
+            snprintf(port_name, sizeof(port_name), "net_tap_%s", pod_id);
 
-            char sock_path[128];
-            snprintf(sock_path, sizeof(sock_path), "/var/run/upe/vhost-%s.sock", pod_id);
+            char devargs[128];
+            snprintf(devargs, sizeof(devargs), "iface=tap_%s", pod_id);
 
-            RTE_LOG(INFO, CTRL, "IPC received: attaching %s at %s\n", port_name, sock_path);
+            RTE_LOG(INFO, CTRL, "IPC received: attaching %s with %s\n", port_name, devargs);
 
-            int port_id = attach_vhost_port(port_name, sock_path);
+            int port_id = attach_tap_port(port_name, devargs);
             if (port_id >= 0 && port_id < MAX_PORTS) {
                 /* Parse the IPv4 address. */
                 struct in_addr addr;
@@ -98,7 +92,6 @@ static void handle_client(int client_fd) {
                 }
 
                 g_ctx->ifaces[port_id].configured = true;
-
                 /* To avoid lock contention in the rx_lcore polling loop, notify it about the new port
                 * using atomic bitmask. */
                 __atomic_or_fetch(&g_ctx->active_ports_mask, (1ULL << port_id), __ATOMIC_RELEASE);
@@ -106,7 +99,38 @@ static void handle_client(int client_fd) {
                 /* Response to the CNI. */
                 const char *resp = "OK\n";
                 write(client_fd, resp, strlen(resp));
+            } else {
+                const char *resp = "ERR\n";
+                write(client_fd, resp, strlen(resp));
+            }
 
+        } else if (strcmp(cmd, "DEL_TAP") == 0 && parsed == 2) {
+
+            char port_name[64];
+            snprintf(port_name, sizeof(port_name), "net_tap_%s", pod_id);
+
+            uint16_t port_id;
+            if (rte_eth_dev_get_port_by_name(port_name, &port_id) == 0) {
+
+                // Stop lx_lcore from polling this port right now.
+                __atomic_and_fetch(&g_ctx->active_ports_mask, ~(1ULL << port_id), __ATOMIC_RELEASE);
+
+                usleep(1000);
+
+                uint32_t ip = g_ctx->ifaces[port_id].ip;
+                lpm_delete(&g_ctx->lpm, ip, 32);
+
+                rte_eth_dev_stop(port_id);
+                rte_eth_dev_close(port_id);
+
+                rte_eal_hotplug_remove("vdev", port_name);
+
+                g_ctx->ifaces[port_id].configured = false;
+
+                RTE_LOG(INFO, CTRL, "IPC received: destroyed %s\n", port_name);
+
+                const char *resp = "OK\n";
+                write(client_fd, resp, strlen(resp));
             } else {
                 const char *resp = "ERR\n";
                 write(client_fd, resp, strlen(resp));

--- a/router/src/ctrl_plane.c
+++ b/router/src/ctrl_plane.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <arpa/inet.h>
 #include <pthread.h>
 #include <sys/socket.h>
 #include <sys/un.h>
@@ -76,7 +77,27 @@ static void handle_client(int client_fd) {
 
             int port_id = attach_vhost_port(port_name, sock_path);
             if (port_id >= 0 && port_id < MAX_PORTS) {
-                /* TODO: Dynamic Route Injection */
+                /* Parse the IPv4 address. */
+                struct in_addr addr;
+                if (inet_pton(AF_INET, ip_str, &addr) == 1) {
+                    g_ctx->ifaces[port_id].ip = addr.s_addr;
+                    g_ctx->ifaces[port_id].netmask = 0xFFFFFFFF;
+
+                    /* Insert it into the DPDK LPM Table. */
+                    if (lpm_insert(&g_ctx->lpm, addr.s_addr, 32, addr.s_addr, port_id) == true) {
+                        RTE_LOG(INFO, CTRL, "LPM injected: Route %s/32 -> Port %d\n", ip_str, port_id);
+                    }
+                }
+
+                /* Parse the MAC Address. */
+                uint8_t mac[6];
+                if (sscanf(mac_str, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
+                    &mac[0], &mac[1], &mac[2], &mac[3], &mac[4], &mac[5]) == 6) {
+                    
+                    memcpy(g_ctx->ifaces[port_id].mac, mac, 6);
+                }
+
+                g_ctx->ifaces[port_id].configured = true;
 
                 /* To avoid lock contention in the rx_lcore polling loop, notify it about the new port
                 * using atomic bitmask. */

--- a/router/src/lpm.c
+++ b/router/src/lpm.c
@@ -78,3 +78,20 @@ bool lpm_lookup(const lpm_table_t *table, uint32_t dest_ip, uint32_t *out_next_h
 
     return false; /* No Route Found */
 }
+
+bool lpm_delete(lpm_table_t *table, uint32_t prefix, uint8_t prefix_len) {
+        if (!table || prefix_len > 32) return false;
+
+        uint32_t mask = compute_mask(prefix_len);
+        uint32_t masked_prefix = prefix &mask;
+
+        for (uint32_t i = 0; i < table->count; i++) {
+            if (table->entries[i].valid && table->entries[i].prefix == masked_prefix &&
+                table->entries[i].prefix_len == prefix_len) {
+                
+                table->entries[i].valid = false;
+                return true;
+            }
+        }
+        return false;
+    }


### PR DESCRIPTION
Extend UPE router with Kubernetes CNI backend feature.

Replaced the DPDK IPC hotplug to use net_tap instead of net_vhost sockets to support Linux containers.

When a new CNI interface is plugged in, the dataplane routing is configured for it in the LPM table with a /32 route.

A bash script was created that aligns to the CNI spec to manage the TAP interface injection into the container network namespaces. 

IPAM is delegated to the standard "host-local" CNI plugin.