### PR TITLE
feat(router): add adaptive polling to reduce power usage

### DIFF
--- a/router/include/router.h
+++ b/router/include/router.h
@@ -29,6 +29,8 @@ typedef struct {
     uint32_t benchmark_duration_sec;
     uint32_t aging_timeout_sec; /* MAC table aging timeout */
     uint32_t link_wait_sec;
+    bool adaptive_sleep;
+    uint32_t sleep_threshold;
 } router_config_t;
 
 /* Router Interface configuration per port */
@@ -70,6 +72,9 @@ typedef struct {
 
     double cycles_per_ns;
     volatile bool stop;
+
+    bool adaptive_sleep;
+    uint32_t sleep_threshold;
 } rx_lcore_ctx_t;
 
 /* Global router state */

--- a/router/src/ctrl_plane.c
+++ b/router/src/ctrl_plane.c
@@ -91,7 +91,7 @@ static void handle_client(int client_fd) {
                     memcpy(g_ctx->ifaces[port_id].mac, mac, 6);
                 }
 
-                g_ctx->ifaces[port_id].configured = true
+                g_ctx->ifaces[port_id].configured = true;
 
                 /* To avoid lock contention in the rx_lcore polling loop, notify it about the new port
                 * using atomic bitmask. */

--- a/router/src/main.c
+++ b/router/src/main.c
@@ -41,6 +41,8 @@ static void print_usage(const char *prog_name) {
     printf("  --benchmark-duration N  Benchmark duration in seconds (default: 10)\n");
     printf("  --aging-timeout N       MAC table aging timeout in seconds (default: 30)\n");
     printf("  --link-wait N           Link wait timeout in seconds (default: 5)\n");
+    printf("  --adaptive-sleep        Enable power-saving adaptive polling loop\n");
+    printf("  --sleep-threshold N     Ignore packets <= N bytes when waking up (default: 0)\n");
     printf("  --help                  Show this help message\n");
     printf("\nExample:\n");
     printf("  %s -c 0x3 -n 4 -- --dev-mode\n", prog_name);
@@ -54,6 +56,8 @@ static int parse_app_args(int argc, char **argv, router_config_t *config) {
     config->benchmark_duration_sec = 10;
     config->aging_timeout_sec = DEFAULT_AGING_TIMEOUT_SEC;
     config->link_wait_sec = DEFAULT_LINK_WAIT_SEC;
+    config->adaptive_sleep = false;
+    config->sleep_threshold = 0;
 
     static struct option long_options[] = {
         {"dev-mode", no_argument, NULL, 'd'},
@@ -61,6 +65,8 @@ static int parse_app_args(int argc, char **argv, router_config_t *config) {
         {"benchmark-duration", required_argument, NULL, 'D'},
         {"aging-timeout", required_argument, NULL, 'a'},
         {"link-wait", required_argument, NULL, 'l'},
+        {"adaptive-sleep", no_argument, NULL, 'S'},
+        {"sleep-threshold", required_argument, NULL, 'T'},
         {"help", no_argument, NULL, 'h'},
         {NULL, 0, NULL, 0}
     };
@@ -95,6 +101,12 @@ static int parse_app_args(int argc, char **argv, router_config_t *config) {
                         log_msg(LOG_ERROR, "Link wait must be 1-60 seconds");
                         return -1;
                     }
+                    break;
+            case 'S':
+                    config->adaptive_sleep = true;
+                    break;
+            case 'T':
+                    config->sleep_threshold = (uint32_t)atoi(optarg);
                     break;
             case 'h':
                     print_usage(argv[0]);
@@ -349,6 +361,13 @@ int main(int argc, char **argv) {
     mac_table_init(&g_router.rx_ctx.mac_table,
                    g_router.config.aging_timeout_sec,
                    cycles_per_ns);
+    
+    g_router.rx_ctx.adaptive_sleep = g_router.config.adaptive_sleep;
+    g_router.rx_ctx.sleep_threshold = g_router.config.sleep_threshold;
+
+    log_msg(LOG_INFO, "Power Saving: adaptive_sleep=%d (threshold=%u bytes)",
+            g_router.config.adaptive_sleep,
+            g_router.config.sleep_threshold);
     
     for (uint16_t i = 0; i < MAX_PORTS; i++) {
         latency_histogram_init(&g_router.rx_ctx.latency_hist[i]);

--- a/router/src/rx_lcore.c
+++ b/router/src/rx_lcore.c
@@ -7,6 +7,7 @@
 #include <rte_icmp.h>
 #include <rte_byteorder.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "latency.h"
 #include "log.h"
@@ -358,19 +359,26 @@ int rx_lcore_main(void *arg) {
 
     struct rte_mbuf *rx_mbufs[BURST_SIZE];
 
+    uint64_t idle_count = 0;
+    const uint64_t IDLE_THRESHOLD = 10000;
+
     while (!ctx->stop) {
         uint64_t active_ports = __atomic_load_n(&ctx->active_ports_mask,
                                                 __ATOMIC_ACQUIRE);
+        bool traffic_exceeds_threshold = false;
 
         for (uint16_t p = 0; p < MAX_PORTS; p++) {
             if (!(active_ports & (1ULL << p))) continue;
-            
+
             uint16_t nb_rx = rte_eth_rx_burst(p, 0, rx_mbufs, BURST_SIZE);
 
             if (nb_rx > 0) {
                 uint64_t ingress_tsc = rdtsc();
 
                 for (uint16_t i = 0; i < nb_rx; i++) {
+                    if (ctx->adaptive_sleep && rx_mbufs[i]->pkt_len > ctx->sleep_threshold) {
+                        traffic_exceeds_threshold = true;
+                    }
                     forward_mbuf(ctx, rx_mbufs[i], p, ingress_tsc);
                 }
             }
@@ -380,6 +388,17 @@ int rx_lcore_main(void *arg) {
         for (uint16_t p = 0; p < MAX_PORTS; p++) {
             if (active_ports & (1ULL << p)) {
                 flush_tx_buffer(p, &ctx->tx_buffers[p]);
+            }
+        }
+
+        if (ctx->adaptive_sleep) {
+            if (!traffic_exceeds_threshold) {
+                idle_count++;
+                if (idle_count > IDLE_THRESHOLD) {
+                    usleep(10);
+                }
+            } else {
+                idle_count = 0;
             }
         }
     }


### PR DESCRIPTION
Introduce --adaptive-sleep and --sleep-threshold N CLI flags to track empty burst cycles in the RX lcore polling loop.

After 10,000 idle cycles, the loop calls usleep(10) to give the CPU an opportunity to enter a low-power C-state. When packet traffic exceeds the configured threshold, polling returns to full speed.

This avoids wasting CPU power during periods of low background traffic, such as keepalives and ARP packets.