### PR TITLE
feat(cni): add crash reconvery reconciler daemon 

### DIFF
--- a/router/bench/mock_dpdk.h
+++ b/router/bench/mock_dpdk.h
@@ -4,7 +4,8 @@
 /* Redirect rdtsc to an ignored name */
 #define rdtsc hardware_rdtsc_ignored
 
-/* Force latency.h (which defined rdtsc()) to load. It will define hardware_rdtsc_ignored instead. */
+/* Force latency.h (which defined rdtsc()) to load. It will define hardware_rdtsc_ignored instead.
+ */
 #include "latency.h"
 
 /* Undefine the redirection so we can use the clean rdtsc name */
@@ -17,13 +18,13 @@
 #define _RTE_MBUF_H_
 #define _RTE_IP_H_
 #define _RTE_ARP_H_
-#define _RTE_ICMP_H_ 
+#define _RTE_ICMP_H_
 #define _RTE_BYTEORDER_H_
 #define _RTE_BYTEORDER_X86_H_
 #define _RTE_BYTEORDER_ARM_H_
 
-#include <stdint.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -89,7 +90,7 @@ static inline void rte_pktmbuf_free(struct rte_mbuf *m) {
 /* Copies metadata only and shares the parent's payload (by copying just the pointer addr) */
 static inline struct rte_mbuf *rte_pktmbuf_clone(struct rte_mbuf *md, void *mp) {
     (void)mp;
-    if(!md) return NULL;
+    if (!md) return NULL;
 
     /* Create a new metadata shell, point buf_addr to the parent's data buffer */
     struct rte_mbuf *clone = (struct rte_mbuf *)malloc(sizeof(struct rte_mbuf));
@@ -108,7 +109,8 @@ static inline struct rte_mbuf *rte_pktmbuf_clone(struct rte_mbuf *md, void *mp) 
 }
 
 /* Deep copies the whole packet, allocating new memory for the payload as well */
-static inline struct rte_mbuf *rte_pktmbuf_copy(const struct rte_mbuf *m, void *pool, uint32_t offset, uint32_t length) {
+static inline struct rte_mbuf *rte_pktmbuf_copy(const struct rte_mbuf *m, void *pool,
+                                                uint32_t offset, uint32_t length) {
     (void)offset;
     (void)length;
     if (!m) return NULL;
@@ -123,7 +125,8 @@ static inline struct rte_mbuf *rte_pktmbuf_copy(const struct rte_mbuf *m, void *
 }
 
 /* Helper to build test packets */
-static inline struct rte_mbuf *mock_build_packet(uint16_t port, const uint8_t *src_mac, const uint8_t *dst_mac, uint16_t ethertype) {
+static inline struct rte_mbuf *mock_build_packet(uint16_t port, const uint8_t *src_mac,
+                                                 const uint8_t *dst_mac, uint16_t ethertype) {
     struct rte_mbuf *m = rte_pktmbuf_alloc(NULL);
     if (!m) return NULL;
 
@@ -146,7 +149,8 @@ static inline uint64_t rdtsc(void) {
 }
 
 /* Mock that the NIC hardware accepted the packets */
-static inline uint16_t rte_eth_tx_burst(uint16_t port_id, uint16_t queue_id, struct rte_mbuf **tx_pkts, uint16_t nb_pkts) {
+static inline uint16_t rte_eth_tx_burst(uint16_t port_id, uint16_t queue_id,
+                                        struct rte_mbuf **tx_pkts, uint16_t nb_pkts) {
     (void)port_id;
     (void)queue_id;
     (void)tx_pkts;
@@ -159,7 +163,8 @@ static inline unsigned int rte_lcore_id(void) {
 }
 
 /* Mock RX burst function */
-static inline uint16_t rte_eth_rx_burst(uint16_t port_id, uint16_t queue_id, struct rte_mbuf **rx_pkts, uint16_t nb_pkts) {
+static inline uint16_t rte_eth_rx_burst(uint16_t port_id, uint16_t queue_id,
+                                        struct rte_mbuf **rx_pkts, uint16_t nb_pkts) {
     (void)port_id;
     (void)queue_id;
     (void)rx_pkts;
@@ -175,66 +180,68 @@ static inline uint16_t rte_eth_rx_burst(uint16_t port_id, uint16_t queue_id, str
 #define rte_cpu_to_be_32(x) __builtin_bswap32(x)
 
 #define RTE_ETHER_TYPE_IPV4 0x0800
-#define RTE_IPV4(a, b, c, d) ((uint32_t)(((a) & 0xff) << 24) | \
-                              (((b) & 0xff) << 16) | \
-                              (((c) & 0xff) << 8)  | \
-                              ((d) & 0xff))
+#define RTE_IPV4(a, b, c, d)                                                                       \
+    ((uint32_t)(((a) & 0xff) << 24) | (((b) & 0xff) << 16) | (((c) & 0xff) << 8) | ((d) & 0xff))
 #define IPPROTO_ICMP 1
-#define RTE_ETHER_TYPE_ARP  0x0806
+#define RTE_ETHER_TYPE_ARP 0x0806
 #define RTE_ARP_HRD_ETHER 1
 #define RTE_ARP_OP_REQUEST 1
-#define RTE_ARP_OP_REPLY   2
+#define RTE_ARP_OP_REPLY 2
 
-static inline void rte_ether_addr_copy(const struct rte_ether_addr *ea_from, struct rte_ether_addr *ea_to) {
+static inline void rte_ether_addr_copy(const struct rte_ether_addr *ea_from,
+                                       struct rte_ether_addr *ea_to) {
     *ea_to = *ea_from;
 }
 
 struct rte_ipv4_hdr {
-    uint8_t  version_ihl;
-    uint8_t  type_of_service;
+    uint8_t version_ihl;
+    uint8_t type_of_service;
     uint16_t total_length;
     uint16_t packet_id;
     uint16_t fragment_offset;
-    uint8_t  time_to_live;
-    uint8_t  next_proto_id;
+    uint8_t time_to_live;
+    uint8_t next_proto_id;
     uint16_t hdr_checksum;
     uint32_t src_addr;
     uint32_t dst_addr;
 } __attribute__((__packed__));
 
 static inline uint16_t rte_ipv4_cksum(const struct rte_ipv4_hdr *ipv4_hdr) {
-    (void)ipv4_hdr; return 0;
+    (void)ipv4_hdr;
+    return 0;
 }
 
 struct rte_arp_ipv4 {
     struct rte_ether_addr arp_sha;
-    uint32_t              arp_sip;
+    uint32_t arp_sip;
     struct rte_ether_addr arp_tha;
-    uint32_t              arp_tip;
+    uint32_t arp_tip;
 } __attribute__((__packed__));
 
 struct rte_arp_hdr {
     uint16_t arp_hardware;
     uint16_t arp_protocol;
-    uint8_t  arp_hlen;
-    uint8_t  arp_plen;
+    uint8_t arp_hlen;
+    uint8_t arp_plen;
     uint16_t arp_opcode;
     struct rte_arp_ipv4 arp_data;
 } __attribute__((__packed__));
 
-#define RTE_IP_ICMP_ECHO_REPLY   0
+#define RTE_IP_ICMP_ECHO_REPLY 0
 #define RTE_IP_ICMP_ECHO_REQUEST 8
 
 struct rte_icmp_hdr {
-    uint8_t  icmp_type;
-    uint8_t  icmp_code;
+    uint8_t icmp_type;
+    uint8_t icmp_code;
     uint16_t icmp_cksum;
     uint16_t icmp_ident;
     uint16_t icmp_seq_nb;
 } __attribute__((__packed__));
 
 static inline uint16_t rte_raw_cksum(const void *buf, size_t len) {
-    (void)buf; (void)len; return 0;
+    (void)buf;
+    (void)len;
+    return 0;
 }
 
 #endif // MOCK_DPDK_H

--- a/router/bench/test_forwarding.c
+++ b/router/bench/test_forwarding.c
@@ -184,17 +184,20 @@ static void test_icmp_echo_reply() {
 
     /* Build ICMP Echo Request packet from Host A to Router's Port 0 IP */
     struct rte_mbuf *pkt = mock_build_packet(0, MAC_HOST_A, MAC_ROUTER_0, RTE_ETHER_TYPE_IPV4);
-    pkt->data_len = sizeof(struct rte_ether_hdr) + sizeof(struct rte_ipv4_hdr) + sizeof(struct rte_icmp_hdr);
+    pkt->data_len =
+        sizeof(struct rte_ether_hdr) + sizeof(struct rte_ipv4_hdr) + sizeof(struct rte_icmp_hdr);
     pkt->pkt_len = pkt->data_len;
 
-    struct rte_ipv4_hdr *ipv4 = (struct rte_ipv4_hdr *)((uint8_t *)pkt->buf_addr + sizeof(struct rte_ether_hdr));
+    struct rte_ipv4_hdr *ipv4 =
+        (struct rte_ipv4_hdr *)((uint8_t *)pkt->buf_addr + sizeof(struct rte_ether_hdr));
     ipv4->version_ihl = 0x45;
     ipv4->time_to_live = 64;
     ipv4->next_proto_id = IPPROTO_ICMP;
     ipv4->src_addr = rte_cpu_to_be_32(RTE_IPV4(10, 128, 0, 50));
     ipv4->dst_addr = IP_ROUTER_0;
 
-    struct rte_icmp_hdr *icmp = (struct rte_icmp_hdr *)((uint8_t *)ipv4 + sizeof(struct rte_ipv4_hdr));
+    struct rte_icmp_hdr *icmp =
+        (struct rte_icmp_hdr *)((uint8_t *)ipv4 + sizeof(struct rte_ipv4_hdr));
     icmp->icmp_type = RTE_IP_ICMP_ECHO_REQUEST;
     icmp->icmp_code = 0;
     icmp->icmp_cksum = 0xFFFF;
@@ -210,13 +213,18 @@ static void test_icmp_echo_reply() {
     if (ctx.tx_buffers[0].count > 0) {
         struct rte_mbuf *reply_pkt = ctx.tx_buffers[0].mbufs[0];
         struct rte_ether_hdr *reply_eth = (struct rte_ether_hdr *)reply_pkt->buf_addr;
-        struct rte_ipv4_hdr *reply_ipv4 = (struct rte_ipv4_hdr *)((uint8_t *)reply_pkt->buf_addr + sizeof(struct rte_ether_hdr));
-        struct rte_icmp_hdr *reply_icmp = (struct rte_icmp_hdr *)((uint8_t *)reply_ipv4 + sizeof(struct rte_ipv4_hdr));
+        struct rte_ipv4_hdr *reply_ipv4 =
+            (struct rte_ipv4_hdr *)((uint8_t *)reply_pkt->buf_addr + sizeof(struct rte_ether_hdr));
+        struct rte_icmp_hdr *reply_icmp =
+            (struct rte_icmp_hdr *)((uint8_t *)reply_ipv4 + sizeof(struct rte_ipv4_hdr));
 
-        ASSERT(memcmp(reply_eth->dst_addr.addr_bytes, MAC_HOST_A, 6) == 0, "Reply DST MAC should be Host A");
-        ASSERT(memcmp(reply_eth->src_addr.addr_bytes, MAC_ROUTER_0, 6) == 0, "Reply SRC MAC should be Router Port 0");
+        ASSERT(memcmp(reply_eth->dst_addr.addr_bytes, MAC_HOST_A, 6) == 0,
+               "Reply DST MAC should be Host A");
+        ASSERT(memcmp(reply_eth->src_addr.addr_bytes, MAC_ROUTER_0, 6) == 0,
+               "Reply SRC MAC should be Router Port 0");
 
-        ASSERT(reply_ipv4->dst_addr == rte_cpu_to_be_32(RTE_IPV4(10, 128, 0, 50)), "Reply DST IP should be Host A");
+        ASSERT(reply_ipv4->dst_addr == rte_cpu_to_be_32(RTE_IPV4(10, 128, 0, 50)),
+               "Reply DST IP should be Host A");
         ASSERT(reply_ipv4->src_addr == IP_ROUTER_0, "Reply SRC IP should be Router Port 0");
         ASSERT(reply_icmp->icmp_type == RTE_IP_ICMP_ECHO_REPLY, "ICMP Type should be Echo Reply");
     }

--- a/router/cni/upe-rtr-cni
+++ b/router/cni/upe-rtr-cni
@@ -31,7 +31,12 @@ if [ "$COMMAND" = "ADD" ]; then
     # Generate random MAC address.
     POD_MAC=$(printf '02:%02x:%02x:%02x:%02x:%02x' $((RANDOM%256)) $((RANDOM%256)) $((RANDOM%256)) $((RANDOM%256)) $((RANDOM%256)))
 
-    echo "ADD_TAP ${POD_ID_SHORT} ${POD_IP} ${POD_MAC}" | nc -U $IPC_SOCKET > /dev/null
+    mkdir -p /var/run/upe/state
+    STATE_FILE="/var/run/upe/state/${CNI_CONTAINERID}.txt"
+
+    echo "ADD_TAP ${POD_ID_SHORT} ${POD_IP} ${POD_MAC}" > "$STATE_FILE"
+
+    cat "$STATE_FILE" | nc -U $IPC_SOCKET > /dev/null
 
     sleep 0.5
 

--- a/router/include/arp4.h
+++ b/router/include/arp4.h
@@ -1,21 +1,21 @@
 #ifndef ARP4_H
 #define ARP4_H
 
-#include <stdint.h>
 #include <stdbool.h>
+#include <stdint.h>
 
-#define ARP_TABLE_CAPACITY  512
-#define ARP_MAX_PROBES      16
+#define ARP_TABLE_CAPACITY 512
+#define ARP_MAX_PROBES 16
 
 typedef struct {
-    uint32_t    ip;     /* Network byte order key */
-    uint8_t     mac[6]; /* Resolved value */
-    bool        occupied;
+    uint32_t ip;    /* Network byte order key */
+    uint8_t mac[6]; /* Resolved value */
+    bool occupied;
 } arp4_entry_t;
 
 typedef struct {
     arp4_entry_t entries[ARP_TABLE_CAPACITY];
-    uint32_t     arp_miss_count;
+    uint32_t arp_miss_count;
 } arp4_table_t;
 
 /* API Methods */

--- a/router/include/lpm.h
+++ b/router/include/lpm.h
@@ -1,28 +1,30 @@
 #ifndef LPM_H
 #define LPM_H
 
-#include <stdint.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 #define LPM_TABLE_CAPACITY 1024
 
 typedef struct {
-    uint32_t    prefix;         /* Network byte order */
-    uint8_t     prefix_len;
-    uint32_t    next_hop_ip;    /* Network byte order */
-    uint16_t    egress_port;
-    bool        valid;
+    uint32_t prefix; /* Network byte order */
+    uint8_t prefix_len;
+    uint32_t next_hop_ip; /* Network byte order */
+    uint16_t egress_port;
+    bool valid;
 } lpm_entry_t;
 
 typedef struct {
     lpm_entry_t entries[LPM_TABLE_CAPACITY];
-    uint32_t    count;
+    uint32_t count;
 } lpm_table_t;
 
 /* API Methods */
 void lpm_init(lpm_table_t *table);
-bool lpm_insert(lpm_table_t *table, uint32_t prefix, uint8_t prefix_len, uint32_t next_hop_ip, uint16_t egress_port);
-bool lpm_lookup(const lpm_table_t *table, uint32_t dest_ip, uint32_t *out_next_hop, uint16_t *out_port);
+bool lpm_insert(lpm_table_t *table, uint32_t prefix, uint8_t prefix_len, uint32_t next_hop_ip,
+                uint16_t egress_port);
+bool lpm_lookup(const lpm_table_t *table, uint32_t dest_ip, uint32_t *out_next_hop,
+                uint16_t *out_port);
 bool lpm_delete(lpm_table_t *table, uint32_t prefix, uint8_t prefix_len);
 
 #endif /* LPM_H */

--- a/router/include/mac_table.h
+++ b/router/include/mac_table.h
@@ -1,12 +1,12 @@
 #ifndef MAC_TABLE_H
 #define MAC_TABLE_H
 
-#include <stdint.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 #define MAC_ADDR_LEN 6
 #define MAC_TABLE_CAPACITY 2048
-#define MAC_TABLE_MAX_PROBE 16  /* Maximum linear probe distance before giving up */
+#define MAC_TABLE_MAX_PROBE 16 /* Maximum linear probe distance before giving up */
 
 typedef struct {
     uint8_t mac[MAC_ADDR_LEN];
@@ -26,9 +26,8 @@ typedef struct {
  * @param table Pointer to table structure
  * @param aging_timeout_sec Aging timeout in seconds
  * @param cycles_per_ns TSC cycles per nanosecond (from calibration)
-*/
-void mac_table_init(mac_table_t *table, uint32_t aging_timeout_sec,
-                    double cycles_per_ns);
+ */
+void mac_table_init(mac_table_t *table, uint32_t aging_timeout_sec, double cycles_per_ns);
 
 /**
  * Insert or update a MAC entry in the table
@@ -36,9 +35,9 @@ void mac_table_init(mac_table_t *table, uint32_t aging_timeout_sec,
  * @param mac MAC address to insert
  * @param port_id Port ID where the MAC was seen
  * @return true if successful, false if table is full
-*/
-bool mac_table_insert(mac_table_t *table, const uint8_t mac[MAC_ADDR_LEN],
-                      uint16_t port_id, uint64_t current_tsc);
+ */
+bool mac_table_insert(mac_table_t *table, const uint8_t mac[MAC_ADDR_LEN], uint16_t port_id,
+                      uint64_t current_tsc);
 
 /**
  * Lookup MAC address in table
@@ -47,15 +46,15 @@ bool mac_table_insert(mac_table_t *table, const uint8_t mac[MAC_ADDR_LEN],
  * @param current_tsc Current TSC value for aging check
  * @param out_port Output for port_id if found
  * @return true if MAC found and not expired, false otherwise
-*/
-bool mac_table_lookup(mac_table_t *table, const uint8_t mac[MAC_ADDR_LEN],
-                      uint64_t current_tsc, uint16_t *out_port);
+ */
+bool mac_table_lookup(mac_table_t *table, const uint8_t mac[MAC_ADDR_LEN], uint64_t current_tsc,
+                      uint16_t *out_port);
 
 /**
  * Check if MAC address is unicast (the first octet's LSB is 0)
  * @param mac MAC address to check
  * @return true if unicast
-*/
+ */
 static inline bool mac_is_unicast(const uint8_t mac[MAC_ADDR_LEN]) {
     return (mac[0] & 0x01) == 0;
 }
@@ -64,10 +63,10 @@ static inline bool mac_is_unicast(const uint8_t mac[MAC_ADDR_LEN]) {
  * Check if MAC address is broadcast (FF:FF:FF:FF:FF:FF)
  * @param mac MAC address to check
  * @return true if broadcast
-*/
+ */
 static inline bool mac_is_broadcast(const uint8_t mac[MAC_ADDR_LEN]) {
-    return mac[0] == 0xFF && mac[1] == 0xFF && mac[2] == 0xFF &&
-           mac[3] == 0xFF && mac[4] == 0xFF && mac[5] == 0xFF;
+    return mac[0] == 0xFF && mac[1] == 0xFF && mac[2] == 0xFF && mac[3] == 0xFF && mac[4] == 0xFF &&
+           mac[5] == 0xFF;
 }
 
 #endif /* MAC_TABLE_H */

--- a/router/include/router.h
+++ b/router/include/router.h
@@ -1,13 +1,13 @@
 #ifndef ROUTER_H
 #define ROUTER_H
 
-#include <stdint.h>
-#include <stdbool.h>
-#include <rte_mbuf.h>
-#include "mac_table.h"
-#include "lpm.h"
 #include "arp4.h"
 #include "latency.h"
+#include "lpm.h"
+#include "mac_table.h"
+#include <rte_mbuf.h>
+#include <stdbool.h>
+#include <stdint.h>
 
 #define MAX_PORTS 64
 
@@ -36,9 +36,9 @@ typedef struct {
 
 /* Router Interface configuration per port */
 typedef struct {
-    uint32_t ip;        /* Network byte order */
-    uint32_t netmask;   /* Network byte order */
-    uint8_t mac[6];     /* Source MAC for egress on this port */
+    uint32_t ip;      /* Network byte order */
+    uint32_t netmask; /* Network byte order */
+    uint8_t mac[6];   /* Source MAC for egress on this port */
     bool configured;
 } router_iface_t;
 
@@ -91,7 +91,6 @@ typedef struct {
 int rx_lcore_main(void *arg);
 void signal_handler(int signum);
 
-int port_init(uint16_t port_id, struct rte_mempool *mbuf_pool,
-              uint32_t link_wait_sec);
+int port_init(uint16_t port_id, struct rte_mempool *mbuf_pool, uint32_t link_wait_sec);
 
 #endif /* ROUTER_H */

--- a/router/scripts/upe-reconciler.sh
+++ b/router/scripts/upe-reconciler.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+SOCKET="/var/run/upe/router.sock"
+STATE_DIR="/var/run/upe/state"
+MARKER="/tmp/upe_reconciled"
+
+mkdir -p "$STATE_DIR"
+
+echo "UPE Reconciler started. Watching for $SOCKET..."
+
+while true; do
+    if [ -S "$SOCKET" ]; then
+        if [ ! -f "$MARKER" ]; then
+            echo "Router socket detected. Reconciling active pods..."
+            for state_file in "$STATE_DIR"/*.txt; do
+                if [ -f "$state_file" ]; then
+                    echo "Sending $state_file to router..."
+                    cat "$state_file" | nc -U "$SOCKET" > /dev/null
+                    sleep 0.1
+                fi
+            done
+            touch "$MARKER"
+            echo "Reconcilation complete."
+        fi
+    else
+        # If socket disappears, the router crashed. Remove marker so we reconcilate
+        # the state when it comes back.
+        rm -f "$MARKER"
+    fi
+    sleep 1
+done

--- a/router/src/ctrl_plane.c
+++ b/router/src/ctrl_plane.c
@@ -1,15 +1,15 @@
+#include <arpa/inet.h>
+#include <pthread.h>
+#include <rte_eal.h>
+#include <rte_ethdev.h>
+#include <rte_log.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
-#include <arpa/inet.h>
-#include <pthread.h>
 #include <sys/socket.h>
-#include <sys/un.h>
 #include <sys/stat.h>
-#include <rte_log.h>
-#include <rte_eal.h>
-#include <rte_ethdev.h>
+#include <sys/un.h>
+#include <unistd.h>
 
 #include "ctrl_plane.h"
 
@@ -52,15 +52,13 @@ static void handle_client(int client_fd) {
     }
     buf[n] = '\0';
 
-    /* Expectation is that the command formatted as: 
+    /* Expectation is that the command formatted as:
      * "ADD_VHOST examplepod 10.128.0.50 00:11:22:33:44:55" */
     char cmd[32], pod_id[64], ip_str[32], mac_str[32];
     int parsed = sscanf(buf, "%31s %63s %31s %31s", cmd, pod_id, ip_str, mac_str);
 
     if (parsed >= 2) {
-
         if (strcmp(cmd, "ADD_TAP") == 0 && parsed == 4) {
-
             char port_name[64];
             snprintf(port_name, sizeof(port_name), "net_tap_%s", pod_id);
 
@@ -79,22 +77,22 @@ static void handle_client(int client_fd) {
 
                     /* Insert it into the DPDK LPM Table. */
                     if (lpm_insert(&g_ctx->lpm, addr.s_addr, 32, addr.s_addr, port_id) == true) {
-                        RTE_LOG(INFO, CTRL, "LPM injected: Route %s/32 -> Port %d\n", ip_str, port_id);
+                        RTE_LOG(INFO, CTRL, "LPM injected: Route %s/32 -> Port %d\n", ip_str,
+                                port_id);
                     }
                 }
 
                 /* Parse the MAC Address. */
                 uint8_t mac[6];
-                if (sscanf(mac_str, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
-                    &mac[0], &mac[1], &mac[2], &mac[3], &mac[4], &mac[5]) == 6) {
-                    
+                if (sscanf(mac_str, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx", &mac[0], &mac[1], &mac[2],
+                           &mac[3], &mac[4], &mac[5]) == 6) {
                     memcpy(g_ctx->ifaces[port_id].mac, mac, 6);
                 }
 
                 g_ctx->ifaces[port_id].configured = true;
 
-                /* To avoid lock contention in the rx_lcore polling loop, notify it about the new port
-                * using atomic bitmask. */
+                /* To avoid lock contention in the rx_lcore polling loop, notify it about the new
+                 * port using atomic bitmask. */
                 __atomic_or_fetch(&g_ctx->active_ports_mask, (1ULL << port_id), __ATOMIC_RELEASE);
 
                 /* Response to the CNI. */
@@ -106,13 +104,11 @@ static void handle_client(int client_fd) {
             }
 
         } else if (strcmp(cmd, "DEL_TAP") == 0 && parsed == 2) {
-
             char port_name[64];
             snprintf(port_name, sizeof(port_name), "net_tap_%s", pod_id);
 
             uint16_t port_id;
             if (rte_eth_dev_get_port_by_name(port_name, &port_id) == 0) {
-
                 // Stop lx_lcore from polling this port right now.
                 __atomic_and_fetch(&g_ctx->active_ports_mask, ~(1ULL << port_id), __ATOMIC_RELEASE);
 

--- a/router/src/lpm.c
+++ b/router/src/lpm.c
@@ -80,18 +80,17 @@ bool lpm_lookup(const lpm_table_t *table, uint32_t dest_ip, uint32_t *out_next_h
 }
 
 bool lpm_delete(lpm_table_t *table, uint32_t prefix, uint8_t prefix_len) {
-        if (!table || prefix_len > 32) return false;
+    if (!table || prefix_len > 32) return false;
 
-        uint32_t mask = compute_mask(prefix_len);
-        uint32_t masked_prefix = prefix &mask;
+    uint32_t mask = compute_mask(prefix_len);
+    uint32_t masked_prefix = prefix & mask;
 
-        for (uint32_t i = 0; i < table->count; i++) {
-            if (table->entries[i].valid && table->entries[i].prefix == masked_prefix &&
-                table->entries[i].prefix_len == prefix_len) {
-                
-                table->entries[i].valid = false;
-                return true;
-            }
+    for (uint32_t i = 0; i < table->count; i++) {
+        if (table->entries[i].valid && table->entries[i].prefix == masked_prefix &&
+            table->entries[i].prefix_len == prefix_len) {
+            table->entries[i].valid = false;
+            return true;
         }
-        return false;
     }
+    return false;
+}

--- a/router/src/main.c
+++ b/router/src/main.c
@@ -1,29 +1,27 @@
+#include <getopt.h>
+#include <signal.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <signal.h>
 #include <unistd.h>
-#include <stdbool.h>
-#include <getopt.h>
 
 /* DPDK headers */
 #include <rte_eal.h>
+#include <rte_errno.h>
 #include <rte_ethdev.h>
+#include <rte_launch.h>
+#include <rte_lcore.h>
 #include <rte_mbuf.h>
 #include <rte_mempool.h>
-#include <rte_lcore.h>
-#include <rte_launch.h>
-#include <rte_errno.h>
 
 /* UPE engine headers */
-#include "log.h"
 #include "latency.h"
+#include "log.h"
 
-#include "router.h"
-#include "mac_table.h"
 #include "ctrl_plane.h"
-
-
+#include "mac_table.h"
+#include "router.h"
 
 static router_state_t g_router;
 
@@ -61,73 +59,69 @@ static int parse_app_args(int argc, char **argv, router_config_t *config) {
     config->sleep_threshold = 0;
     config->quiet = false;
 
-    static struct option long_options[] = {
-        {"dev-mode", no_argument, NULL, 'd'},
-        {"benchmark", no_argument, NULL, 'b'},
-        {"benchmark-duration", required_argument, NULL, 'D'},
-        {"aging-timeout", required_argument, NULL, 'a'},
-        {"link-wait", required_argument, NULL, 'l'},
-        {"adaptive-sleep", no_argument, NULL, 'S'},
-        {"sleep-threshold", required_argument, NULL, 'T'},
-        {"quiet", no_argument, NULL, 'q'},
-        {"help", no_argument, NULL, 'h'},
-        {NULL, 0, NULL, 0}
-    };
+    static struct option long_options[] = {{"dev-mode", no_argument, NULL, 'd'},
+                                           {"benchmark", no_argument, NULL, 'b'},
+                                           {"benchmark-duration", required_argument, NULL, 'D'},
+                                           {"aging-timeout", required_argument, NULL, 'a'},
+                                           {"link-wait", required_argument, NULL, 'l'},
+                                           {"adaptive-sleep", no_argument, NULL, 'S'},
+                                           {"sleep-threshold", required_argument, NULL, 'T'},
+                                           {"quiet", no_argument, NULL, 'q'},
+                                           {"help", no_argument, NULL, 'h'},
+                                           {NULL, 0, NULL, 0}};
 
     int opt;
     while ((opt = getopt_long(argc, argv, "", long_options, NULL)) != -1) {
         switch (opt) {
-            case 'd':
-                config->dev_mode = true;
-                break;
-            case 'b':
-                config->benchmark_mode = true;
-                break;
-            case 'D':
-                config->benchmark_duration_sec = (uint32_t)atoi(optarg);
-                if (config->benchmark_duration_sec < 1 ||
-                    config->benchmark_duration_sec > 3600) {
-                        log_msg(LOG_ERROR, "Benchmark duration must be 1-3600 seconds");
-                        return -1;
-                    }
-                    break;
-            case 'a':
-                    config->aging_timeout_sec = (uint32_t)atoi(optarg);
-                    if (config->aging_timeout_sec < 1) {
-                        log_msg(LOG_ERROR, "Aging timeout must be >= 1 second");
-                        return -1;
-                    }
-                    break;
-            case 'l':
-                    config->link_wait_sec = (uint32_t)atoi(optarg);
-                    if (config->link_wait_sec < 1 || config->link_wait_sec > 60) {
-                        log_msg(LOG_ERROR, "Link wait must be 1-60 seconds");
-                        return -1;
-                    }
-                    break;
-            case 'S':
-                    config->adaptive_sleep = true;
-                    break;
-            case 'T':
-                    config->sleep_threshold = (uint32_t)atoi(optarg);
-                    break;
-            case 'q':
-                    config->quiet = true;
-                    break;
-            case 'h':
-                    print_usage(argv[0]);
-                    exit(0);
-            default:
-                    print_usage(argv[0]);
-                    return -1;
+        case 'd':
+            config->dev_mode = true;
+            break;
+        case 'b':
+            config->benchmark_mode = true;
+            break;
+        case 'D':
+            config->benchmark_duration_sec = (uint32_t)atoi(optarg);
+            if (config->benchmark_duration_sec < 1 || config->benchmark_duration_sec > 3600) {
+                log_msg(LOG_ERROR, "Benchmark duration must be 1-3600 seconds");
+                return -1;
+            }
+            break;
+        case 'a':
+            config->aging_timeout_sec = (uint32_t)atoi(optarg);
+            if (config->aging_timeout_sec < 1) {
+                log_msg(LOG_ERROR, "Aging timeout must be >= 1 second");
+                return -1;
+            }
+            break;
+        case 'l':
+            config->link_wait_sec = (uint32_t)atoi(optarg);
+            if (config->link_wait_sec < 1 || config->link_wait_sec > 60) {
+                log_msg(LOG_ERROR, "Link wait must be 1-60 seconds");
+                return -1;
+            }
+            break;
+        case 'S':
+            config->adaptive_sleep = true;
+            break;
+        case 'T':
+            config->sleep_threshold = (uint32_t)atoi(optarg);
+            break;
+        case 'q':
+            config->quiet = true;
+            break;
+        case 'h':
+            print_usage(argv[0]);
+            exit(0);
+        default:
+            print_usage(argv[0]);
+            return -1;
         }
     }
 
     return 0;
 }
 
-int port_init(uint16_t port_id, struct rte_mempool *mbuf_pool,
-                     uint32_t link_wait_sec) {
+int port_init(uint16_t port_id, struct rte_mempool *mbuf_pool, uint32_t link_wait_sec) {
     struct rte_eth_conf port_conf = {0};
     const uint16_t rx_rings = 1;
     const uint16_t tx_rings = 1;
@@ -139,60 +133,53 @@ int port_init(uint16_t port_id, struct rte_mempool *mbuf_pool,
     /* Get device info */
     ret = rte_eth_dev_info_get(port_id, &dev_info);
     if (ret != 0) {
-        log_msg(LOG_ERROR, "Failed to get device info for port %u: %s",
-                port_id, rte_strerror(-ret));
+        log_msg(LOG_ERROR, "Failed to get device info for port %u: %s", port_id,
+                rte_strerror(-ret));
         return ret;
     }
 
     /* Configure the device */
     ret = rte_eth_dev_configure(port_id, rx_rings, tx_rings, &port_conf);
     if (ret != 0) {
-        log_msg(LOG_ERROR, "Failed to configure port %u: %s",
-                port_id, rte_strerror(-ret));
+        log_msg(LOG_ERROR, "Failed to configure port %u: %s", port_id, rte_strerror(-ret));
         return ret;
     }
 
     /* Adjust descriptor counts if needed */
     ret = rte_eth_dev_adjust_nb_rx_tx_desc(port_id, &nb_rxd, &nb_txd);
     if (ret != 0) {
-        log_msg(LOG_ERROR, "Failed to adjust descriptor counts for port %u: %s",
-                port_id, rte_strerror(-ret));
+        log_msg(LOG_ERROR, "Failed to adjust descriptor counts for port %u: %s", port_id,
+                rte_strerror(-ret));
         return ret;
     }
 
     /* Setup RX queue */
-    ret = rte_eth_rx_queue_setup(port_id, 0, nb_rxd,
-                                 rte_eth_dev_socket_id(port_id),
-                                 NULL, mbuf_pool);
+    ret =
+        rte_eth_rx_queue_setup(port_id, 0, nb_rxd, rte_eth_dev_socket_id(port_id), NULL, mbuf_pool);
     if (ret < 0) {
-        log_msg(LOG_ERROR, "Failed to setup RX queue for port %u: %s",
-                port_id, rte_strerror(-ret));
+        log_msg(LOG_ERROR, "Failed to setup RX queue for port %u: %s", port_id, rte_strerror(-ret));
         return ret;
     }
 
     /* Setup TX queue */
-    ret = rte_eth_tx_queue_setup(port_id, 0, nb_txd,
-                                 rte_eth_dev_socket_id(port_id),
-                                 NULL);
+    ret = rte_eth_tx_queue_setup(port_id, 0, nb_txd, rte_eth_dev_socket_id(port_id), NULL);
     if (ret < 0) {
-        log_msg(LOG_ERROR, "Failed to setup TX queue for port %u: %s",
-                port_id, rte_strerror(-ret));
+        log_msg(LOG_ERROR, "Failed to setup TX queue for port %u: %s", port_id, rte_strerror(-ret));
         return ret;
     }
 
     /* Start the device */
     ret = rte_eth_dev_start(port_id);
     if (ret < 0) {
-        log_msg(LOG_ERROR, "Failed to start port %u: %s",
-                port_id, rte_strerror(-ret));
+        log_msg(LOG_ERROR, "Failed to start port %u: %s", port_id, rte_strerror(-ret));
         return ret;
     }
 
     /* Enable promiscuous mode */
     ret = rte_eth_promiscuous_enable(port_id);
     if (ret != 0) {
-        log_msg(LOG_ERROR, "Failed to enable promiscuous mode on port %u: %s",
-                port_id, rte_strerror(-ret));
+        log_msg(LOG_ERROR, "Failed to enable promiscuous mode on port %u: %s", port_id,
+                rte_strerror(-ret));
         return ret;
     }
 
@@ -204,16 +191,14 @@ int port_init(uint16_t port_id, struct rte_mempool *mbuf_pool,
     do {
         ret = rte_eth_link_get_nowait(port_id, &link);
         if (ret < 0) {
-            log_msg(LOG_ERROR, "Failed to get link status for port %u: %s",
-                    port_id, rte_strerror(-ret));
+            log_msg(LOG_ERROR, "Failed to get link status for port %u: %s", port_id,
+                    rte_strerror(-ret));
             return ret;
         }
 
         if (link.link_status == RTE_ETH_LINK_UP) {
-            log_msg(LOG_INFO, "Port %u: Link up. Speed %u Mbps, %s",
-                    port_id, link.link_speed,
-                    (link.link_duplex == RTE_ETH_LINK_FULL_DUPLEX) ? 
-                    "full-duplex": "half-duplex");
+            log_msg(LOG_INFO, "Port %u: Link up. Speed %u Mbps, %s", port_id, link.link_speed,
+                    (link.link_duplex == RTE_ETH_LINK_FULL_DUPLEX) ? "full-duplex" : "half-duplex");
             return 0;
         }
 
@@ -222,8 +207,8 @@ int port_init(uint16_t port_id, struct rte_mempool *mbuf_pool,
     } while (wait_count < max_wait);
 
     /* Link still down after timeout */
-    log_msg(LOG_WARN, "Port %u: Link down after %u second timeout, continuing anyway",
-            port_id, link_wait_sec);
+    log_msg(LOG_WARN, "Port %u: Link down after %u second timeout, continuing anyway", port_id,
+            link_wait_sec);
     return 0;
 }
 
@@ -242,17 +227,15 @@ static void print_stats(const rx_lcore_ctx_t *ctx) {
 
         log_msg(LOG_INFO,
                 "Port %u: pkts=%lu, p50=%lu ns, p99=%lu ns, p999=%lu ns, "
-                 "min=%lu ns, max=%lu ns",
-                 port, hist->total_count, p50, p99, p999,
-                 hist->min_ns, hist->max_ns);
+                "min=%lu ns, max=%lu ns",
+                port, hist->total_count, p50, p99, p999, hist->min_ns, hist->max_ns);
     }
 
     log_msg(LOG_INFO,
             "Forwarding: pkts=%lu, bytes=%lu, flooded=%lu, dropped=%lu, "
             "pool_exhausted=%lu, mac_table_full=%lu",
-            ctx->packets_forwarded, ctx->bytes_forwarded,
-            ctx->packets_flooded, ctx->packets_dropped,
-            ctx->pool_exhaustion_count, ctx->mac_table.table_full_count);
+            ctx->packets_forwarded, ctx->bytes_forwarded, ctx->packets_flooded,
+            ctx->packets_dropped, ctx->pool_exhaustion_count, ctx->mac_table.table_full_count);
 }
 
 int main(int argc, char **argv) {
@@ -265,8 +248,7 @@ int main(int argc, char **argv) {
 
     ret = rte_eal_init(argc, argv);
     if (ret < 0) {
-        log_msg(LOG_ERROR, "EAL initialization failed: %s",
-                rte_strerror(rte_errno));
+        log_msg(LOG_ERROR, "EAL initialization failed: %s", rte_strerror(rte_errno));
         return EXIT_FAILURE;
     }
 
@@ -281,8 +263,7 @@ int main(int argc, char **argv) {
 
     unsigned int nb_lcores = rte_lcore_count();
     if (nb_lcores < 2) {
-        log_msg(LOG_ERROR, "At least 2 lcores are required (main + 1 worker), got %u",
-                nb_lcores);
+        log_msg(LOG_ERROR, "At least 2 lcores are required (main + 1 worker), got %u", nb_lcores);
         rte_eal_cleanup();
         return EXIT_FAILURE;
     }
@@ -293,18 +274,11 @@ int main(int argc, char **argv) {
     log_msg(LOG_INFO, "TSC calibration: %.2f cycles/ns", cycles_per_ns);
     g_router.rx_ctx.cycles_per_ns = cycles_per_ns;
 
-    g_router.mbuf_pool = rte_pktmbuf_pool_create(
-        "mbuf_pool",
-        MBUF_POOL_SIZE,
-        MBUF_CACHE_SIZE,
-        0,
-        MBUF_DATA_SIZE,
-        rte_socket_id()
-    );
+    g_router.mbuf_pool = rte_pktmbuf_pool_create("mbuf_pool", MBUF_POOL_SIZE, MBUF_CACHE_SIZE, 0,
+                                                 MBUF_DATA_SIZE, rte_socket_id());
 
     if (g_router.mbuf_pool == NULL) {
-        log_msg(LOG_ERROR, "Failed to create mbuf pool: %s",
-                rte_strerror(rte_errno));
+        log_msg(LOG_ERROR, "Failed to create mbuf pool: %s", rte_strerror(rte_errno));
         rte_eal_cleanup();
         return EXIT_FAILURE;
     }
@@ -317,16 +291,14 @@ int main(int argc, char **argv) {
 
         ret = rte_eal_hotplug_add("vdev", "net_tap0", "");
         if (ret < 0) {
-            log_msg(LOG_ERROR, "Failed to create net_tap0: %s",
-                    rte_strerror(-ret));
+            log_msg(LOG_ERROR, "Failed to create net_tap0: %s", rte_strerror(-ret));
             rte_eal_cleanup();
             return EXIT_FAILURE;
         }
 
         ret = rte_eal_hotplug_add("vdev", "net_tap1", "");
         if (ret < 0) {
-            log_msg(LOG_ERROR, "Failed to create net_tap1: %s",
-                    rte_strerror(-ret));
+            log_msg(LOG_ERROR, "Failed to create net_tap1: %s", rte_strerror(-ret));
             rte_eal_cleanup();
             return EXIT_FAILURE;
         }
@@ -352,11 +324,9 @@ int main(int argc, char **argv) {
 
         g_router.rx_ctx.active_ports_mask |= (1ULL << port_id);
 
-        ret = port_init(port_id, g_router.mbuf_pool,
-                        g_router.config.link_wait_sec);
+        ret = port_init(port_id, g_router.mbuf_pool, g_router.config.link_wait_sec);
         if (ret < 0) {
-            log_msg(LOG_ERROR, "Failed to initialize port %u",
-                    port_id);
+            log_msg(LOG_ERROR, "Failed to initialize port %u", port_id);
             rte_eal_cleanup();
             return EXIT_FAILURE;
         }
@@ -364,17 +334,14 @@ int main(int argc, char **argv) {
         log_msg(LOG_INFO, "Initialized port %u", port_id);
     }
 
-    mac_table_init(&g_router.rx_ctx.mac_table,
-                   g_router.config.aging_timeout_sec,
-                   cycles_per_ns);
-    
+    mac_table_init(&g_router.rx_ctx.mac_table, g_router.config.aging_timeout_sec, cycles_per_ns);
+
     g_router.rx_ctx.adaptive_sleep = g_router.config.adaptive_sleep;
     g_router.rx_ctx.sleep_threshold = g_router.config.sleep_threshold;
 
     log_msg(LOG_INFO, "Power Saving: adaptive_sleep=%d (threshold=%u bytes)",
-            g_router.config.adaptive_sleep,
-            g_router.config.sleep_threshold);
-    
+            g_router.config.adaptive_sleep, g_router.config.sleep_threshold);
+
     for (uint16_t i = 0; i < MAX_PORTS; i++) {
         latency_histogram_init(&g_router.rx_ctx.latency_hist[i]);
         g_router.rx_ctx.tx_buffers[i].count = 0;
@@ -405,11 +372,9 @@ int main(int argc, char **argv) {
     log_msg(LOG_INFO, "Launching RX worker on lcore %u", lcore_id);
 
     /* Launch RX worker on dedicated lcore */
-    ret = rte_eal_remote_launch(rx_lcore_main, &g_router.rx_ctx,
-                                lcore_id);
+    ret = rte_eal_remote_launch(rx_lcore_main, &g_router.rx_ctx, lcore_id);
     if (ret < 0) {
-        log_msg(LOG_ERROR, "Failed to launch RX worker: %s",
-                rte_strerror(-ret));
+        log_msg(LOG_ERROR, "Failed to launch RX worker: %s", rte_strerror(-ret));
         rte_eal_cleanup();
         return EXIT_FAILURE;
     }
@@ -429,8 +394,7 @@ int main(int argc, char **argv) {
         if (g_router.config.benchmark_mode) {
             uint64_t current_tsc = rdtsc();
             uint64_t elapsed_tsc = current_tsc - g_router.start_tsc;
-            double elapsed_sec = (double)elapsed_tsc /
-                                 (cycles_per_ns * 1000000000.0);
+            double elapsed_sec = (double)elapsed_tsc / (cycles_per_ns * 1000000000.0);
 
             if (elapsed_sec >= g_router.config.benchmark_duration_sec) {
                 g_router.end_tsc = current_tsc;
@@ -455,16 +419,14 @@ int main(int argc, char **argv) {
 
     /* Print final stats */
     if (g_router.config.benchmark_mode) {
-        double duration_sec = (double)(g_router.end_tsc - g_router.start_tsc) /
-                                (cycles_per_ns * 1000000000.0);
+        double duration_sec =
+            (double)(g_router.end_tsc - g_router.start_tsc) / (cycles_per_ns * 1000000000.0);
         double pps = (double)g_router.rx_ctx.packets_forwarded / duration_sec;
-        double gbps = (double)g_router.rx_ctx.bytes_forwarded * 8.0 /
-                        (duration_sec * 1000000000.0);
-        
+        double gbps = (double)g_router.rx_ctx.bytes_forwarded * 8.0 / (duration_sec * 1000000000.0);
+
         uint64_t p50 = 0, p99 = 0, p999 = 0, min_ns = 0, max_ns = 0;
         for (uint16_t port = 0; port < MAX_PORTS; port++) {
-            const latency_histogram_t * hist =
-                &g_router.rx_ctx.latency_hist[port];
+            const latency_histogram_t *hist = &g_router.rx_ctx.latency_hist[port];
             if (hist->total_count > 0) {
                 p50 = latency_percentile(hist, 0.50);
                 p99 = latency_percentile(hist, 0.99);
@@ -475,7 +437,7 @@ int main(int argc, char **argv) {
             }
         }
 
-            /* Print JSON to stdout */
+        /* Print JSON to stdout */
         printf("{\n");
         printf("  \"duration_sec\": %.3f,\n", duration_sec);
         printf("  \"results\": {\n");
@@ -510,8 +472,7 @@ int main(int argc, char **argv) {
         log_msg(LOG_INFO, "Stopping port %u", port_id);
         ret = rte_eth_dev_stop(port_id);
         if (ret != 0) {
-            log_msg(LOG_ERROR, "Failed to stop port %u: %s",
-                    port_id, rte_strerror(-ret));
+            log_msg(LOG_ERROR, "Failed to stop port %u: %s", port_id, rte_strerror(-ret));
         }
 
         rte_eth_dev_close(port_id);

--- a/router/src/rx_lcore.c
+++ b/router/src/rx_lcore.c
@@ -1,20 +1,20 @@
+#include <rte_arp.h>
+#include <rte_byteorder.h>
 #include <rte_eal.h>
 #include <rte_ethdev.h>
 #include <rte_ether.h>
-#include <rte_mbuf.h>
-#include <rte_ip.h>
-#include <rte_arp.h>
 #include <rte_icmp.h>
-#include <rte_byteorder.h>
+#include <rte_ip.h>
+#include <rte_mbuf.h>
 #include <string.h>
 #include <unistd.h>
 
+#include "arp4.h"
 #include "latency.h"
 #include "log.h"
+#include "lpm.h"
 #include "mac_table.h"
 #include "router.h"
-#include "arp4.h"
-#include "lpm.h"
 
 /* Get pointer to the Ethernet header inside an mbuf. */
 static inline struct rte_ether_hdr *eth_hdr(struct rte_mbuf *mbuf) {
@@ -51,11 +51,13 @@ static void send_arp_request(rx_lcore_ctx_t *ctx, struct rte_mbuf *mbuf, uint16_
     mbuf->pkt_len = pkt_len;
 
     struct rte_ether_hdr *eth = eth_hdr(mbuf);
-    struct rte_arp_hdr *arp = rte_pktmbuf_mtod_offset(mbuf, struct rte_arp_hdr *, sizeof(struct rte_ether_hdr));
+    struct rte_arp_hdr *arp =
+        rte_pktmbuf_mtod_offset(mbuf, struct rte_arp_hdr *, sizeof(struct rte_ether_hdr));
 
     /* Ethernet hdr */
     memset(&eth->dst_addr, 0xFF, 6); /* Broadcast */
-    rte_ether_addr_copy((const struct rte_ether_addr *)ctx->ifaces[egress_port].mac, &eth->src_addr);
+    rte_ether_addr_copy((const struct rte_ether_addr *)ctx->ifaces[egress_port].mac,
+                        &eth->src_addr);
     eth->ether_type = rte_cpu_to_be_16(RTE_ETHER_TYPE_ARP);
 
     /* ARP hdr */
@@ -65,7 +67,8 @@ static void send_arp_request(rx_lcore_ctx_t *ctx, struct rte_mbuf *mbuf, uint16_
     arp->arp_plen = 4;
     arp->arp_opcode = rte_cpu_to_be_16(RTE_ARP_OP_REQUEST);
 
-    rte_ether_addr_copy((const struct rte_ether_addr *)ctx->ifaces[egress_port].mac, &arp->arp_data.arp_sha);
+    rte_ether_addr_copy((const struct rte_ether_addr *)ctx->ifaces[egress_port].mac,
+                        &arp->arp_data.arp_sha);
     arp->arp_data.arp_sip = ctx->ifaces[egress_port].ip;
     memset(&arp->arp_data.arp_tha, 0, 6);
     arp->arp_data.arp_tip = target_ip;
@@ -74,15 +77,17 @@ static void send_arp_request(rx_lcore_ctx_t *ctx, struct rte_mbuf *mbuf, uint16_
 }
 
 /* Handle ARP packets (requests, replies). */
-static bool handle_arp(rx_lcore_ctx_t *ctx, struct rte_mbuf *mbuf, uint16_t ingress_port, uint64_t ingress_tsc) {
+static bool handle_arp(rx_lcore_ctx_t *ctx, struct rte_mbuf *mbuf, uint16_t ingress_port,
+                       uint64_t ingress_tsc) {
     if (!ctx->ifaces[ingress_port].configured) return false;
 
     struct rte_ether_hdr *eth = eth_hdr(mbuf);
-    struct rte_arp_hdr *arp = rte_pktmbuf_mtod_offset(mbuf, struct rte_arp_hdr *, sizeof(struct rte_ether_hdr));
+    struct rte_arp_hdr *arp =
+        rte_pktmbuf_mtod_offset(mbuf, struct rte_arp_hdr *, sizeof(struct rte_ether_hdr));
 
     if (rte_be_to_cpu_16(arp->arp_hardware) != RTE_ARP_HRD_ETHER ||
-        rte_be_to_cpu_16(arp->arp_protocol) != RTE_ETHER_TYPE_IPV4 ||
-        arp->arp_hlen != 6 || arp->arp_plen != 4) {
+        rte_be_to_cpu_16(arp->arp_protocol) != RTE_ETHER_TYPE_IPV4 || arp->arp_hlen != 6 ||
+        arp->arp_plen != 4) {
         return false;
     }
 
@@ -94,21 +99,24 @@ static bool handle_arp(rx_lcore_ctx_t *ctx, struct rte_mbuf *mbuf, uint16_t ingr
     if (op == RTE_ARP_OP_REQUEST) {
         if (tip == my_ip) {
             rte_ether_addr_copy(&eth->src_addr, &eth->dst_addr);
-            rte_ether_addr_copy((const struct rte_ether_addr *)ctx->ifaces[ingress_port].mac, &eth->src_addr);
+            rte_ether_addr_copy((const struct rte_ether_addr *)ctx->ifaces[ingress_port].mac,
+                                &eth->src_addr);
 
             arp->arp_opcode = rte_cpu_to_be_16(RTE_ARP_OP_REPLY);
 
             rte_ether_addr_copy(&arp->arp_data.arp_sha, &arp->arp_data.arp_tha);
             arp->arp_data.arp_tip = arp->arp_data.arp_sip;
 
-            rte_ether_addr_copy((const struct rte_ether_addr *)ctx->ifaces[ingress_port].mac, &arp->arp_data.arp_sha);
+            rte_ether_addr_copy((const struct rte_ether_addr *)ctx->ifaces[ingress_port].mac,
+                                &arp->arp_data.arp_sha);
             arp->arp_data.arp_sip = my_ip;
 
             /* Learn the sender's MAC, IP. */
             arp4_insert(&ctx->arp4, sip, arp->arp_data.arp_tha.addr_bytes);
 
             uint64_t egress_tsc = rdtsc();
-            latency_record(&ctx->latency_hist[ingress_port], egress_tsc - ingress_tsc, ctx->cycles_per_ns);
+            latency_record(&ctx->latency_hist[ingress_port], egress_tsc - ingress_tsc,
+                           ctx->cycles_per_ns);
             enqueue_tx(ingress_port, &ctx->tx_buffers[ingress_port], mbuf);
 
             return true;
@@ -126,9 +134,11 @@ static bool handle_arp(rx_lcore_ctx_t *ctx, struct rte_mbuf *mbuf, uint16_t ingr
 }
 
 /* Handle ICMP Echo Requests to the router. */
-static bool handle_icmp_echo(rx_lcore_ctx_t *ctx, struct rte_mbuf *mbuf, uint16_t ingress_port, uint64_t ingress_tsc) {
+static bool handle_icmp_echo(rx_lcore_ctx_t *ctx, struct rte_mbuf *mbuf, uint16_t ingress_port,
+                             uint64_t ingress_tsc) {
     struct rte_ether_hdr *eth = eth_hdr(mbuf);
-    struct rte_ipv4_hdr *ipv4 = rte_pktmbuf_mtod_offset(mbuf, struct rte_ipv4_hdr *, sizeof(struct rte_ether_hdr));
+    struct rte_ipv4_hdr *ipv4 =
+        rte_pktmbuf_mtod_offset(mbuf, struct rte_ipv4_hdr *, sizeof(struct rte_ether_hdr));
 
     uint16_t ihl_bytes = (ipv4->version_ihl & 0x0f) * 4;
     struct rte_icmp_hdr *icmp = (struct rte_icmp_hdr *)((uint8_t *)ipv4 + ihl_bytes);
@@ -136,7 +146,8 @@ static bool handle_icmp_echo(rx_lcore_ctx_t *ctx, struct rte_mbuf *mbuf, uint16_
     if (icmp->icmp_type == RTE_IP_ICMP_ECHO_REQUEST) {
         /* Swap MACs */
         rte_ether_addr_copy(&eth->src_addr, &eth->dst_addr);
-        rte_ether_addr_copy((const struct rte_ether_addr *)ctx->ifaces[ingress_port].mac, &eth->src_addr);
+        rte_ether_addr_copy((const struct rte_ether_addr *)ctx->ifaces[ingress_port].mac,
+                            &eth->src_addr);
 
         /* Swap IPs */
         uint32_t tmp_ip = ipv4->src_addr;
@@ -153,7 +164,8 @@ static bool handle_icmp_echo(rx_lcore_ctx_t *ctx, struct rte_mbuf *mbuf, uint16_
         icmp->icmp_cksum = ~cksum & 0xFFFF;
 
         uint64_t egress_tsc = rdtsc();
-        latency_record(&ctx->latency_hist[ingress_port], egress_tsc - ingress_tsc, ctx->cycles_per_ns);
+        latency_record(&ctx->latency_hist[ingress_port], egress_tsc - ingress_tsc,
+                       ctx->cycles_per_ns);
         enqueue_tx(ingress_port, &ctx->tx_buffers[ingress_port], mbuf);
 
         return true;
@@ -163,11 +175,13 @@ static bool handle_icmp_echo(rx_lcore_ctx_t *ctx, struct rte_mbuf *mbuf, uint16_
 }
 
 /* Handle IPv4 packets */
-static bool handle_ipv4(rx_lcore_ctx_t *ctx, struct rte_mbuf *mbuf, uint16_t ingress_port, uint64_t ingress_tsc) {
+static bool handle_ipv4(rx_lcore_ctx_t *ctx, struct rte_mbuf *mbuf, uint16_t ingress_port,
+                        uint64_t ingress_tsc) {
     if (!ctx->ifaces[ingress_port].configured) return false;
 
     struct rte_ether_hdr *eth = eth_hdr(mbuf);
-    struct rte_ipv4_hdr *ipv4 = rte_pktmbuf_mtod_offset(mbuf, struct rte_ipv4_hdr *, sizeof(struct rte_ether_hdr));
+    struct rte_ipv4_hdr *ipv4 =
+        rte_pktmbuf_mtod_offset(mbuf, struct rte_ipv4_hdr *, sizeof(struct rte_ether_hdr));
 
     uint32_t dst_ip = ipv4->dst_addr;
 
@@ -175,7 +189,7 @@ static bool handle_ipv4(rx_lcore_ctx_t *ctx, struct rte_mbuf *mbuf, uint16_t ing
     for (uint16_t i = 0; i < MAX_PORTS; i++) {
         if (ctx->ifaces[i].configured && ctx->ifaces[i].ip == dst_ip) {
             ctx->packets_local++;
-           
+
             /* Responding to ICMP */
             if (ipv4->next_proto_id == IPPROTO_ICMP) {
                 if (handle_icmp_echo(ctx, mbuf, ingress_port, ingress_tsc)) {
@@ -224,7 +238,8 @@ static bool handle_ipv4(rx_lcore_ctx_t *ctx, struct rte_mbuf *mbuf, uint16_t ing
     ipv4->hdr_checksum = 0;
     ipv4->hdr_checksum = rte_ipv4_cksum(ipv4);
 
-    rte_ether_addr_copy((const struct rte_ether_addr *)ctx->ifaces[egress_port].mac, &eth->src_addr);
+    rte_ether_addr_copy((const struct rte_ether_addr *)ctx->ifaces[egress_port].mac,
+                        &eth->src_addr);
     rte_ether_addr_copy((const struct rte_ether_addr *)next_hop_mac, &eth->dst_addr);
 
     uint64_t egress_tsc = rdtsc();
@@ -278,7 +293,7 @@ static void forward_mbuf(rx_lcore_ctx_t *ctx, struct rte_mbuf *mbuf, uint16_t in
             return;
         }
 
-        /* If it's broadcast (DHCP, LLDP...) and not consumed, 
+        /* If it's broadcast (DHCP, LLDP...) and not consumed,
          * fall through to L2 flooding. */
     }
 
@@ -310,8 +325,7 @@ static void forward_mbuf(rx_lcore_ctx_t *ctx, struct rte_mbuf *mbuf, uint16_t in
         uint16_t egress_ports[MAX_PORTS];
         uint16_t n_egress = 0;
 
-        uint64_t active_ports = __atomic_load_n(&ctx->active_ports_mask,
-                                                __ATOMIC_ACQUIRE);
+        uint64_t active_ports = __atomic_load_n(&ctx->active_ports_mask, __ATOMIC_ACQUIRE);
 
         for (uint16_t p = 0; p < MAX_PORTS; p++) {
             /* Port's bit should be 1 and not ingress port. */
@@ -363,8 +377,7 @@ int rx_lcore_main(void *arg) {
     const uint64_t IDLE_THRESHOLD = 10000;
 
     while (!ctx->stop) {
-        uint64_t active_ports = __atomic_load_n(&ctx->active_ports_mask,
-                                                __ATOMIC_ACQUIRE);
+        uint64_t active_ports = __atomic_load_n(&ctx->active_ports_mask, __ATOMIC_ACQUIRE);
         bool traffic_exceeds_threshold = false;
 
         for (uint16_t p = 0; p < MAX_PORTS; p++) {
@@ -406,8 +419,7 @@ int rx_lcore_main(void *arg) {
     log_msg(LOG_INFO, "RX lcore %u stopping, will flush TX buffers...", rte_lcore_id());
 
     /* Final flush before shutdown. */
-    uint64_t active_ports = __atomic_load_n(&ctx->active_ports_mask,
-                                            __ATOMIC_ACQUIRE);
+    uint64_t active_ports = __atomic_load_n(&ctx->active_ports_mask, __ATOMIC_ACQUIRE);
     for (uint16_t p = 0; p < MAX_PORTS; p++) {
         if (active_ports & (1ULL << p)) {
             flush_tx_buffer(p, &ctx->tx_buffers[p]);


### PR DESCRIPTION
Introduces a background reconciler that watches the router's IPC socket.
The CNI plugin now persists pod network states to disk, allowing the
reconciler to restore the DPDK data plane and TAP interfaces if the
UPE router crashes and restarts.