### PR TITLE
feat(cni): add crash reconvery reconciler daemon

### DIFF
--- a/router/cni/upe-rtr-cni
+++ b/router/cni/upe-rtr-cni
@@ -31,7 +31,12 @@ if [ "$COMMAND" = "ADD" ]; then
     # Generate random MAC address.
     POD_MAC=$(printf '02:%02x:%02x:%02x:%02x:%02x' $((RANDOM%256)) $((RANDOM%256)) $((RANDOM%256)) $((RANDOM%256)) $((RANDOM%256)))
 
-    echo "ADD_TAP ${POD_ID_SHORT} ${POD_IP} ${POD_MAC}" | nc -U $IPC_SOCKET > /dev/null
+    mkdir -p /var/run/upe/state
+    STATE_FILE="/var/run/upe/state/${CNI_CONTAINERID}.txt"
+
+    echo "ADD_TAP ${POD_ID_SHORT} ${POD_IP} ${POD_MAC}" > "$STATE_FILE"
+
+    cat "$STATE_FILE" | nc -U $IPC_SOCKET > /dev/null
 
     sleep 0.5
 

--- a/router/scripts/upe-reconciler.sh
+++ b/router/scripts/upe-reconciler.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+SOCKET="/var/run/upe/router.sock"
+STATE_DIR="/var/run/upe/state"
+MARKER="/tmp/upe_reconciled"
+
+mkdir -p "$STATE_DIR"
+
+echo "UPE Reconciler started. Watching for $SOCKET..."
+
+while true; do
+    if [ -S "$SOCKET" ]; then
+        if [ ! -f "$MARKER" ]; then
+            echo "Router socket detected. Reconciling active pods..."
+            for state_file in "$STATE_DIR"/*.txt; do
+                if [ -f "$state_file" ]; then
+                    echo "Sending $state_file to router..."
+                    cat "$state_file" | nc -U "$SOCKET" > /dev/null
+                    sleep 0.1
+                fi
+            done
+            touch "$MARKER"
+            echo "Reconcilation complete."
+        fi
+    else
+        # If socket disappears, the router crashed. Remove marker so we reconcilate
+        # the state when it comes back.
+        rm -f "$MARKER"
+    fi
+    sleep 1
+done


### PR DESCRIPTION
Introduces a background reconciler that watches the router's IPC socket. The CNI plugin now persists pod network states to disk, allowing the reconciler to restore the DPDK data plane and TAP interfaces if the UPE router crashes and restarts.